### PR TITLE
Fix: Removes build dependencies in the same layer to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,16 +8,16 @@ COPY client/ ./
 RUN npm run build
 
 # Production stage
-FROM node:18-alpine
+FROM node:18-alpine AS production
 WORKDIR /app
-
-# Install build dependencies
-RUN apk add --no-cache python3 make g++ gcc
 
 # Copy server source and dependencies
 WORKDIR /app
 COPY server/package.json ./
-RUN npm install --production
+RUN apk add --no-cache --virtual .build-deps python3 make g++ gcc && \
+      npm install --omit=dev && \
+      apk del .build-deps
+
 COPY server/src ./src
 
 # Copy client build
@@ -25,9 +25,6 @@ COPY --from=client-build /app/client/build /client/build
 
 # Create output directory
 RUN mkdir -p ./data/snippets
-
-# Clean up build dependencies to reduce image size
-RUN apk del python3 make g++ gcc
 
 EXPOSE 5000
 


### PR DESCRIPTION
Due to how Docker and the overlay file system works, removing files in a different layer than they were added does not actually remove the size from the image, just the files.

This PR installs and removes everything in the same layer, roughly halving the image size:

```bash
docker image ls | grep bytestash
bytestash                                    new                37fbc72db5ac   About a minute ago   286MB
bytestash                                    original           110e0fb81259   6 minutes ago        534MB
```