### PR TITLE
Feature: Use the docker/metadata-action to set tags and labels for image

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -48,7 +48,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: ${{ github.repository == 'jordan-dalby/ByteStash' }}
+          push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
           platforms: linux/amd64
           tags: ${{ steps.docker-metadata.outputs.tags }}
           labels: ${{ steps.docker-metadata.outputs.labels }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,10 +3,6 @@ name: Build and Push Docker Image for Pull Request Testing
 on:
   pull_request:
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: jordan-dalby/bytestash-dev
-
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -21,13 +17,24 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
-          username: jordan-dalby
-          password: ${{ secrets.DOCKER_PAT }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set Docker tag with PR number
-        id: docker_tag
-        run: echo "TAG=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+      - name: Set ghcr repository name
+        id: set-ghcr-repository
+        run: |
+          ghcr_name=$(echo "${{ github.repository }}" | awk '{ print tolower($0) }')
+          echo "ghcr-repository=${ghcr_name}" >> $GITHUB_OUTPUT
+
+      - name: Set Docker image metadata
+        id: docker-metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ steps.set-ghcr-repository.outputs.ghcr-repository }}
+          tags: |
+            type=ref,event=pr
 
       - name: Set up QEMU for cross-platform builds
         uses: docker/setup-qemu-action@v3
@@ -43,4 +50,5 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64
-          tags: ${{ env.TAG }}
+          tags: ${{ steps.docker-metadata.outputs.tags }}
+          labels: ${{ steps.docker-metadata.outputs.labels }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -48,7 +48,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: true
+          push: false
           platforms: linux/amd64
           tags: ${{ steps.docker-metadata.outputs.tags }}
           labels: ${{ steps.docker-metadata.outputs.labels }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -48,7 +48,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: false
+          push: ${{ github.repository == 'jordan-dalby/ByteStash' }}
           platforms: linux/amd64
           tags: ${{ steps.docker-metadata.outputs.tags }}
           labels: ${{ steps.docker-metadata.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,6 @@ on:
     types: [published]
   workflow_dispatch:
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: jordan-dalby/bytestash
-
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -23,9 +19,26 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set ghcr repository name
+        id: set-ghcr-repository
+        run: |
+          ghcr_name=$(echo "${{ github.repository }}" | awk '{ print tolower($0) }')
+          echo "ghcr-repository=${ghcr_name}" >> $GITHUB_OUTPUT
+
+      - name: Set Docker image metadata
+        id: docker-metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ steps.set-ghcr-repository.outputs.ghcr-repository }}
+            name=${{ github.repository }},enable=false
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
 
       - name: Set up QEMU for cross-platform builds
         uses: docker/setup-qemu-action@v3
@@ -41,6 +54,5 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64,linux/arm/v7
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
+          tags: ${{ steps.docker-metadata.outputs.tags }}
+          labels: ${{ steps.docker-metadata.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           images: |
             ghcr.io/${{ steps.set-ghcr-repository.outputs.ghcr-repository }}
-            name=${{ github.repository }},enable=false
+            name=docker.io/${{ github.repository }},enable=false
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
This PR updates the workflows to use [docker/metadata-action](https://github.com/docker/metadata-action) to set both image tags and labels.

For a PR, this sets a tag such as [pr-1](https://github.com/stumpylog/ByteStash/actions/runs/12015956090/job/33495127511#step:5:38) and a bunch of useful [labels](https://github.com/stumpylog/ByteStash/actions/runs/12015956090/job/33495127511#step:5:41)

For a release, this does update slightly, to produce both a `:latest`, a `:version` and a `:major.minor`, which looks like [this](https://github.com/stumpylog/ByteStash/actions/runs/12015994854/job/33495253685#step:5:42) with basically the same [labels](https://github.com/stumpylog/ByteStash/actions/runs/12015994854/job/33495253685#step:5:47)

Some other updates:
- This should allow forks to build and publish an image if they want
- Instead of needing a Personal Access Token, `${{ secrets.GITHUB_TOKEN }}` will have permissions already
- Uses the `${{ github.actor }}` instead of hard coding that, again for better fork support
- Disabled example of pushing to Docker Hub