### PR TITLE
Allow favicon.ico to be loaded with subpath

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -50,13 +50,13 @@ app.use(`${basePath}/assets`, express.static(assetsPath));
 app.use(`${basePath}/monacoeditorwork`, express.static(join(buildPath, 'monacoeditorwork')));
 app.use(basePath, express.static(buildPath, { index: false }));
 
-/* 
+/*
  * A bit of a hack, we need to manually rewrite the HTML to support base paths with ingress
  * If given a base path of /bytestash, the index.html file will still be using /assets/xyz.css
  * But of course the files are not there on ingress, so we need to change them to /bytestash/assets/xyz.css
  * It's a bit of a hacky mess but this is the only solution I figured out without directly modifying vite.config.ts
  * on the client, but this will affect everyone, so not a viable solution
- * 
+ *
  * We're also injecting the base path into the HTML so that the client can know the value without relying on an
  * environment variable, which would be baked into the client code at build time, which is not acceptable in this case
  */
@@ -64,21 +64,21 @@ app.get(`${basePath}/*`, (req, res, next) => {
   if (req.url.startsWith(`${basePath}/api`)) {
     return next();
   }
-  
+
   // Don't cache, if the base path changes the previous index.html file is still used which will have incorrect paths
   res.set({
     'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
     'Pragma': 'no-cache',
     'Expires': '0',
   });
-  
+
   fs.readFile(join(buildPath, 'index.html'), 'utf8', (err, data) => {
     if (err) {
       return res.status(500).send('Error loading index.html');
     }
-    
+
     const modifiedHtml = data.replace(
-      /(src|href)="\/assets\//g, 
+      /(src|href)="\/assets\//g,
       `$1="${basePath}/assets/`
     ).replace(
       /\/monacoeditorwork\//g,
@@ -86,6 +86,9 @@ app.get(`${basePath}/*`, (req, res, next) => {
     ).replace(
       /(href)="\/manifest\.json"/g,
       `$1="${basePath}/manifest.json"`
+    ).replace(
+      /(href)="\/favicon\.ico"/g,
+      `$1="${basePath}/favicon.ico"`
     );
 
     const scriptInjection = `<script>window.__BASE_PATH__ = "${basePath}";</script>`;
@@ -93,22 +96,22 @@ app.get(`${basePath}/*`, (req, res, next) => {
       '</head>',
       `${scriptInjection}</head>`
     );
-    
+
     res.send(injectedHtml);
   });
 });
 
 function handleShutdown() {
   Logger.info('Received shutdown signal, starting graceful shutdown...');
-  
+
   shutdownDatabase();
-  
+
   process.exit(0);
 }
 
 (async () => {
   await initializeDatabase();
-  
+
   return new Promise((resolve) => {
     app.listen(PORT, () => {
       Logger.info(`Server running on port ${PORT}`);


### PR DESCRIPTION
Hi @jordan-dalby,

I've just found out that the frontend cannot load the icon `favicon.ico` when using the subpath.

So I create this PR to fix that, just like the PR #169 . I've tested in my local and it worked, please have a look.

Thanks,