### PR TITLE
Add pikapods.com install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,12 @@ ByteStash is a self-hosted web application designed to store, organise, and mana
 
 ## Howto
 ### Unraid
-ByteStash is now on the Unraid App Store! Install it from there.
+ByteStash is now on the Unraid App Store! Install it from [there](https://unraid.net/community/apps).
 
-### Other
+### PikaPods
+Also available on [PikaPods](https://www.pikapods.com/) for [1-click install](https://www.pikapods.com/pods?run=bytestash) from $1/month.
+
+### Docker
 ByteStash can also be hosted manually via the docker-compose file:
 ```yaml
 services:


### PR DESCRIPTION
Hey there,

Manu, the founder of [pikapods.com](https://www.pikapods.com) here. We make it easy to run the best open source apps and deal with details, like server maintenance, updates, migrations and backups.

Our users have asked us to add BytesStash as new app, which we already did: https://www.pikapods.com/apps#new

Now I wanted to reach out if there is any interest in adding this install option to the README to allow users to quickly run the app. Especially if they don't manage their own server.

In addition, we could set up a pod to use as demo installation for users to try out the app. And we offer a revenue share to all authors, if that should be relevant now or later.

Looking forward to any feedback.

Thanks!