### PR TITLE
`preferred_username` considered first when generating usernames

### DIFF
--- a/server/src/repositories/userRepository.js
+++ b/server/src/repositories/userRepository.js
@@ -136,9 +136,9 @@ class UserRepository {
           .slice(0, 30);
       };
 
-      let baseUsername = profile.name ? sanitizeName(profile.name) :
-                        profile.preferred_username ? sanitizeName(profile.preferred_username) :
+      let baseUsername = profile.preferred_username ? sanitizeName(profile.preferred_username) :
                         profile.email?.split('@')[0] || 
+                        profile.name ? sanitizeName(profile.name) :
                         profile.sub;
                           
       const username = await this.generateUniqueUsername(baseUsername);


### PR DESCRIPTION
@jordan-dalby I hope this is OK.  I know it's really nit-picky, but I found it odd that the `preferred_username` was not considered first when generating a username 🙃

If accepted, this PR considers the `preferred_username` first, followed by `email` (everything before the `@`), _then_ `name`, and finally `sub`

Otherwise, really liking the app so far, just added it to my homelab this evening.  Looking forward to getting some good use out of it!