### PR TITLE
Refactor/init schema and update imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,9 @@
         "concurrently": "^8.2.2",
         "cross-env": "^7.0.3",
         "wait-on": "^7.2.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "client": {
@@ -10792,6 +10795,9 @@
       "devDependencies": {
         "jest": "^29.7.0",
         "supertest": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     }
   }

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -74,6 +74,7 @@ app.get(`${basePath}/*`, (req, res, next) => {
 
   fs.readFile(join(buildPath, 'index.html'), 'utf8', (err, data) => {
     if (err) {
+      Logger.error('Failed to read index.html:', err)
       return res.status(500).send('Error loading index.html');
     }
 

--- a/server/src/config/database.js
+++ b/server/src/config/database.js
@@ -78,76 +78,8 @@ function backupDatabase(dbPath) {
 }
 
 function createInitialSchema(db) {
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS users (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      username TEXT UNIQUE NOT NULL,
-      username_normalized TEXT,
-      password_hash TEXT NOT NULL,
-      oidc_id TEXT,
-      oidc_provider TEXT,
-      email TEXT,
-      name TEXT,
-      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
-    );
-
-    CREATE TABLE IF NOT EXISTS snippets (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      title TEXT NOT NULL,
-      description TEXT,
-      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-      user_id INTEGER REFERENCES users(id),
-      is_public BOOLEAN DEFAULT FALSE
-    );
-
-    CREATE TABLE IF NOT EXISTS categories (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      snippet_id INTEGER,
-      name TEXT NOT NULL,
-      FOREIGN KEY (snippet_id) REFERENCES snippets(id) ON DELETE CASCADE
-    );
-
-    CREATE TABLE IF NOT EXISTS fragments (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      snippet_id INTEGER NOT NULL,
-      file_name TEXT NOT NULL,
-      code TEXT NOT NULL,
-      language TEXT NOT NULL,
-      position INTEGER NOT NULL,
-      FOREIGN KEY (snippet_id) REFERENCES snippets(id) ON DELETE CASCADE
-    );
-
-    CREATE TABLE IF NOT EXISTS shared_snippets (
-      id TEXT PRIMARY KEY,
-      snippet_id INTEGER NOT NULL,
-      requires_auth BOOLEAN NOT NULL DEFAULT false,
-      expires_at DATETIME,
-      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-      FOREIGN KEY (snippet_id) REFERENCES snippets(id) ON DELETE CASCADE
-    );
-
-    CREATE TABLE IF NOT EXISTS api_keys (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      user_id INTEGER NOT NULL,
-      key TEXT NOT NULL UNIQUE,
-      name TEXT NOT NULL,
-      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-      last_used_at DATETIME,
-      is_active BOOLEAN DEFAULT TRUE,
-      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-    );
-
-    CREATE INDEX IF NOT EXISTS idx_users_username ON users(username);
-    CREATE INDEX IF NOT EXISTS idx_snippets_user_id ON snippets(user_id);
-    CREATE INDEX IF NOT EXISTS idx_categories_snippet_id ON categories(snippet_id);
-    CREATE INDEX IF NOT EXISTS idx_fragments_snippet_id ON fragments(snippet_id);
-    CREATE INDEX IF NOT EXISTS idx_shared_snippets_snippet_id ON shared_snippets(snippet_id);
-    CREATE INDEX idx_snippets_is_public ON snippets(is_public);
-    CREATE UNIQUE INDEX IF NOT EXISTS idx_users_username_normalized ON users(username_normalized COLLATE NOCASE);
-    CREATE UNIQUE INDEX IF NOT EXISTS idx_users_oidc ON users(oidc_id, oidc_provider) WHERE oidc_id IS NOT NULL AND oidc_provider IS NOT NULL;
-    CREATE INDEX IF NOT EXISTS idx_api_keys_user_id ON api_keys(user_id);
-    CREATE INDEX IF NOT EXISTS idx_api_keys_key ON api_keys(key);
-  `);
+  const initSQL = fs.readFileSync(path.join(__dirname, 'schema/init.sql'), 'utf8');
+  db.exec(initSQL);
 }
 
 function initializeDatabase() {

--- a/server/src/config/schema/init.sql
+++ b/server/src/config/schema/init.sql
@@ -1,0 +1,82 @@
+CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT UNIQUE NOT NULL,
+    username_normalized TEXT,
+    password_hash TEXT NOT NULL,
+    oidc_id TEXT,
+    oidc_provider TEXT,
+    email TEXT,
+    name TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS snippets (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT NOT NULL,
+    description TEXT,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    user_id INTEGER REFERENCES users (id),
+    is_public BOOLEAN DEFAULT FALSE
+);
+
+CREATE TABLE IF NOT EXISTS categories (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    snippet_id INTEGER,
+    name TEXT NOT NULL,
+    FOREIGN KEY (snippet_id) REFERENCES snippets (id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS fragments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    snippet_id INTEGER NOT NULL,
+    file_name TEXT NOT NULL,
+    code TEXT NOT NULL,
+    language TEXT NOT NULL,
+    position INTEGER NOT NULL,
+    FOREIGN KEY (snippet_id) REFERENCES snippets (id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS shared_snippets (
+    id TEXT PRIMARY KEY,
+    snippet_id INTEGER NOT NULL,
+    requires_auth BOOLEAN NOT NULL DEFAULT false,
+    expires_at DATETIME,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (snippet_id) REFERENCES snippets (id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS api_keys (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    key TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    last_used_at DATETIME,
+    is_active BOOLEAN DEFAULT TRUE,
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_username ON users (username);
+
+CREATE INDEX IF NOT EXISTS idx_snippets_user_id ON snippets (user_id);
+
+CREATE INDEX IF NOT EXISTS idx_categories_snippet_id ON categories (snippet_id);
+
+CREATE INDEX IF NOT EXISTS idx_fragments_snippet_id ON fragments (snippet_id);
+
+CREATE INDEX IF NOT EXISTS idx_shared_snippets_snippet_id ON shared_snippets (snippet_id);
+
+CREATE INDEX idx_snippets_is_public ON snippets (is_public);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_username_normalized ON users (
+    username_normalized COLLATE NOCASE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_oidc ON users (oidc_id, oidc_provider)
+WHERE
+    oidc_id IS NOT NULL
+    AND oidc_provider IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_api_keys_user_id ON api_keys (user_id);
+
+CREATE INDEX IF NOT EXISTS idx_api_keys_key ON api_keys (key);


### PR DESCRIPTION
- Moved the hardcoded db.exec() schema definition into a separate init.sql file located in schema/init.sql.
- Updated the createInitialSchema function to read and execute the SQL from the file.

This improves readability and maintainability for future schema changes.