### PR TITLE
Lvk/add get endpoint for snippets via api

### DIFF
--- a/server/src/routes/apiSnippetRoutes.js
+++ b/server/src/routes/apiSnippetRoutes.js
@@ -16,7 +16,7 @@ router.get('/', authenticateApiKey, async (req, res) => {
     const snippets = await snippetService.getAllSnippets(req.user.id);
     res.status(200).json(snippets);
   } catch (error) {
-    Logger.error('Error in GET /api/snippets:', error);
+    Logger.error('Error in GET /api/v1/snippets:', error);
     res.status(500).json({ error: 'Internal server error' });
   }
 });

--- a/server/src/routes/apiSnippetRoutes.js
+++ b/server/src/routes/apiSnippetRoutes.js
@@ -21,6 +21,24 @@ router.get('/', authenticateApiKey, async (req, res) => {
   }
 });
 
+router.get('/:id', authenticateApiKey, async (req, res) => {
+  try {
+    if (!req.user) {
+      return res.status(401).json({ error: 'API key required' });
+    }
+
+    const snippet = await snippetService.findById(req.params.id, req.user.id);
+    if (!snippet) {
+      res.status(404).json({ error: 'Snippet not found' });
+    } else {
+      res.status(200).json(snippet);
+    }
+  } catch (error) {
+    Logger.error('Error in GET /api/v1/snippets/:id:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
 router.post('/push', authenticateApiKey, upload.array('files'), async (req, res) => {
   try {
     if (!req.user) {


### PR DESCRIPTION
Added additional GET endpoint to /api/v1/snippets for retrieving one snippet by ID.

Used existing GET endpoint from /api/snippets as template, and adjusted with changes similar to the one you added for GET /api/v1/snippets, with appropriate user check.

Also corrected a slight mistake in the error log for the method you added to mention the correct api.