### PR TITLE
[181] Add raw access to snippets

### DIFF
--- a/client/src/components/common/buttons/RawButton.tsx
+++ b/client/src/components/common/buttons/RawButton.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { Check, Code } from 'lucide-react';
+
+export interface RawButtonProps {
+  isPublicView: boolean;
+  snippetId: string;
+  fragmentId: string;
+}
+
+const RawButton: React.FC<RawButtonProps> = ({ isPublicView, snippetId, fragmentId }) => {
+  const [isOpenRaw, setIsOpenRaw] = useState(false);
+
+  const handleOpenRaw = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    try {
+      if (isPublicView) {
+        window.open(`/api/public/snippets/${snippetId}/${fragmentId}/raw`, '_blank');
+      } else {
+        window.open(`/api/snippets/${snippetId}/${fragmentId}/raw`, '_blank');
+      }
+    } catch (err) {
+      console.error('Failed to open raw: ', err);
+    }
+      
+    setIsOpenRaw(true);
+    setTimeout(() => setIsOpenRaw(false), 2000);
+  };
+
+  return (
+    <button
+      onClick={handleOpenRaw}
+      className="absolute top-2 right-10 p-1 bg-light-surface dark:bg-dark-surface rounded-md 
+        hover:bg-light-hover dark:hover:bg-dark-hover transition-colors text-light-text dark:text-dark-text"
+      title="Open Raw"
+    >
+      {isOpenRaw ? (
+        <Check size={16} className="text-light-primary dark:text-dark-primary" />
+      ) : (
+        <Code size={16} className="text-light-text dark:text-dark-text" />
+      )}
+    </button>
+  );
+};
+
+export default RawButton;

--- a/client/src/components/editor/FullCodeBlock.tsx
+++ b/client/src/components/editor/FullCodeBlock.tsx
@@ -5,17 +5,24 @@ import { vscDarkPlus, oneLight } from 'react-syntax-highlighter/dist/cjs/styles/
 import { getLanguageLabel, getMonacoLanguage } from '../../utils/language/languageUtils';
 import CopyButton from '../common/buttons/CopyButton';
 import { useTheme } from '../../contexts/ThemeContext';
+import RawButton from '../common/buttons/RawButton';
 
 export interface FullCodeBlockProps {
   code: string;
   language?: string;
   showLineNumbers?: boolean;
+  isPublicView?: boolean;
+  snippetId?: string;
+  fragmentId?: string;
 }
 
 export const FullCodeBlock: React.FC<FullCodeBlockProps> = ({ 
   code, 
   language = 'plaintext',
-  showLineNumbers = true
+  showLineNumbers = true,
+  isPublicView,
+  snippetId,
+  fragmentId
 }) => {
   const { theme } = useTheme();
   const [effectiveTheme, setEffectiveTheme] = useState<'light' | 'dark'>(
@@ -138,6 +145,13 @@ export const FullCodeBlock: React.FC<FullCodeBlockProps> = ({
         )}
 
         <CopyButton text={code} />
+        {isPublicView !== undefined && snippetId !== undefined && fragmentId !== undefined && (
+          <RawButton
+            isPublicView={isPublicView}
+            snippetId={snippetId}
+            fragmentId={fragmentId}
+          />
+        )}
       </div>
     </div>
   );

--- a/client/src/components/editor/PreviewCodeBlock.tsx
+++ b/client/src/components/editor/PreviewCodeBlock.tsx
@@ -5,27 +5,34 @@ import { vscDarkPlus, oneLight } from 'react-syntax-highlighter/dist/cjs/styles/
 import { getLanguageLabel, getMonacoLanguage } from '../../utils/language/languageUtils';
 import CopyButton from '../common/buttons/CopyButton';
 import { useTheme } from '../../contexts/ThemeContext';
+import RawButton from '../common/buttons/RawButton';
 
 interface PreviewCodeBlockProps {
   code: string;
   language?: string;
   previewLines?: number;
   showLineNumbers?: boolean;
+  isPublicView?: boolean;
+  snippetId?: string;
+  fragmentId?: string;
 }
 
 export const PreviewCodeBlock: React.FC<PreviewCodeBlockProps> = ({
   code,
   language = 'plaintext',
   previewLines = 4,
-  showLineNumbers = true
+  showLineNumbers = true,
+  isPublicView,
+  snippetId,
+  fragmentId
 }) => {
   const { theme } = useTheme();
   const [effectiveTheme, setEffectiveTheme] = useState<'light' | 'dark'>(
-    theme === 'system' 
+    theme === 'system'
       ? window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
       : theme
   );
-  
+
   useEffect(() => {
     const updateEffectiveTheme = () => {
       if (theme === 'system') {
@@ -134,15 +141,22 @@ export const PreviewCodeBlock: React.FC<PreviewCodeBlockProps> = ({
           </div>
         )}
 
-        <div 
+        <div
           className="absolute inset-x-0 bottom-0 bg-gradient-to-t to-transparent pointer-events-none rounded-b-lg"
-          style={{ 
+          style={{
             height: `${LINE_HEIGHT * 2}px`,
             background: `linear-gradient(to top, ${backgroundColor}, transparent)`
           }}
         />
 
         <CopyButton text={code} />
+        {isPublicView !== undefined && snippetId !== undefined && fragmentId !== undefined && (
+          <RawButton
+            isPublicView={isPublicView}
+            snippetId={snippetId}
+            fragmentId={fragmentId}
+          />
+        )}
       </div>
     </div>
   );

--- a/client/src/components/snippets/list/SnippetCard.tsx
+++ b/client/src/components/snippets/list/SnippetCard.tsx
@@ -100,6 +100,15 @@ export const SnippetCard: React.FC<SnippetCardProps> = ({
     onDuplicate(snippet);
   };
 
+  const handleOpenRaw = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (isPublicView) {
+      window.open(`/api/public/snippets/${snippet.id}/raw`, '_blank');
+    } else {
+      window.open(`/api/snippets/${snippet.id}/raw`, '_blank');
+    }
+  };
+
   const currentFragment = snippet.fragments[currentFragmentIndex];
 
   return (
@@ -166,6 +175,7 @@ export const SnippetCard: React.FC<SnippetCardProps> = ({
                 }}
                 onOpenInNewTab={handleOpenInNewTab}
                 onDuplicate={handleDuplicate}
+                onOpenRaw={handleOpenRaw}
                 isPublicView={isPublicView}
                 isAuthenticated={isAuthenticated}
               />

--- a/client/src/components/snippets/list/SnippetCard.tsx
+++ b/client/src/components/snippets/list/SnippetCard.tsx
@@ -100,15 +100,6 @@ export const SnippetCard: React.FC<SnippetCardProps> = ({
     onDuplicate(snippet);
   };
 
-  const handleOpenRaw = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (isPublicView) {
-      window.open(`/api/public/snippets/${snippet.id}/raw`, '_blank');
-    } else {
-      window.open(`/api/snippets/${snippet.id}/raw`, '_blank');
-    }
-  };
-
   const currentFragment = snippet.fragments[currentFragmentIndex];
 
   return (
@@ -175,7 +166,6 @@ export const SnippetCard: React.FC<SnippetCardProps> = ({
                 }}
                 onOpenInNewTab={handleOpenInNewTab}
                 onDuplicate={handleDuplicate}
-                onOpenRaw={handleOpenRaw}
                 isPublicView={isPublicView}
                 isAuthenticated={isAuthenticated}
               />
@@ -238,6 +228,9 @@ export const SnippetCard: React.FC<SnippetCardProps> = ({
                 language={currentFragment.language}
                 previewLines={previewLines}
                 showLineNumbers={showLineNumbers}
+                isPublicView={isPublicView}
+                snippetId={snippet.id}
+                fragmentId={currentFragment.id}
               />
             </div>
           )}

--- a/client/src/components/snippets/list/SnippetCardMenu.tsx
+++ b/client/src/components/snippets/list/SnippetCardMenu.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from 'react';
-import { Share, Pencil, Trash2, ExternalLink, MoreVertical, Copy } from 'lucide-react';
+import { Share, Pencil, Trash2, ExternalLink, MoreVertical, Copy, Code } from 'lucide-react';
 import { IconButton } from '../../common/buttons/IconButton';
 import { useOutsideClick } from '../../../hooks/useOutsideClick';
 
@@ -9,6 +9,7 @@ interface SnippetCardMenuProps {
   onShare: (e: React.MouseEvent) => void;
   onOpenInNewTab: () => void;
   onDuplicate: (e: React.MouseEvent) => void;
+  onOpenRaw: (e: React.MouseEvent) => void;
   isPublicView: boolean;
   isAuthenticated: boolean;
 }
@@ -19,8 +20,9 @@ const SnippetCardMenu: React.FC<SnippetCardMenuProps> = ({
   onShare,
   onOpenInNewTab,
   onDuplicate,
+  onOpenRaw,
   isPublicView,
-  isAuthenticated
+  isAuthenticated,
 }) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -31,6 +33,17 @@ const SnippetCardMenu: React.FC<SnippetCardMenuProps> = ({
   if (isPublicView) {
     return (
       <div className="top-4 right-4 flex items-center gap-1">
+        <IconButton
+          icon={<Code size={16} />}
+          onClick={(e: React.MouseEvent) => {
+            e.stopPropagation();
+            onOpenRaw(e);
+          }}
+          variant="custom"
+          size="sm"
+          className="bg-light-hover dark:bg-dark-hover hover:bg-light-surface dark:hover:bg-dark-surface"
+          label="Open Raw"
+        />
         {isAuthenticated && (
           <IconButton
             icon={<Copy size={16} />}
@@ -61,6 +74,17 @@ const SnippetCardMenu: React.FC<SnippetCardMenuProps> = ({
 
   return (
     <div className="top-4 right-4 flex items-center gap-1">
+      <IconButton
+        icon={<Code size={16} />}
+        onClick={(e: React.MouseEvent) => {
+          e.stopPropagation();
+          onOpenRaw(e);
+        }}
+        variant="custom"
+        size="sm"
+        className="bg-light-hover dark:bg-dark-hover hover:bg-light-surface dark:hover:bg-dark-surface"
+        label="Open Raw"
+      />
       <IconButton
         icon={<Pencil size={16} />}
         onClick={(e: React.MouseEvent) => {

--- a/client/src/components/snippets/list/SnippetCardMenu.tsx
+++ b/client/src/components/snippets/list/SnippetCardMenu.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from 'react';
-import { Share, Pencil, Trash2, ExternalLink, MoreVertical, Copy, Code } from 'lucide-react';
+import { Share, Pencil, Trash2, ExternalLink, MoreVertical, Copy } from 'lucide-react';
 import { IconButton } from '../../common/buttons/IconButton';
 import { useOutsideClick } from '../../../hooks/useOutsideClick';
 
@@ -9,7 +9,6 @@ interface SnippetCardMenuProps {
   onShare: (e: React.MouseEvent) => void;
   onOpenInNewTab: () => void;
   onDuplicate: (e: React.MouseEvent) => void;
-  onOpenRaw: (e: React.MouseEvent) => void;
   isPublicView: boolean;
   isAuthenticated: boolean;
 }
@@ -20,7 +19,6 @@ const SnippetCardMenu: React.FC<SnippetCardMenuProps> = ({
   onShare,
   onOpenInNewTab,
   onDuplicate,
-  onOpenRaw,
   isPublicView,
   isAuthenticated,
 }) => {
@@ -33,17 +31,6 @@ const SnippetCardMenu: React.FC<SnippetCardMenuProps> = ({
   if (isPublicView) {
     return (
       <div className="top-4 right-4 flex items-center gap-1">
-        <IconButton
-          icon={<Code size={16} />}
-          onClick={(e: React.MouseEvent) => {
-            e.stopPropagation();
-            onOpenRaw(e);
-          }}
-          variant="custom"
-          size="sm"
-          className="bg-light-hover dark:bg-dark-hover hover:bg-light-surface dark:hover:bg-dark-surface"
-          label="Open Raw"
-        />
         {isAuthenticated && (
           <IconButton
             icon={<Copy size={16} />}
@@ -74,17 +61,6 @@ const SnippetCardMenu: React.FC<SnippetCardMenuProps> = ({
 
   return (
     <div className="top-4 right-4 flex items-center gap-1">
-      <IconButton
-        icon={<Code size={16} />}
-        onClick={(e: React.MouseEvent) => {
-          e.stopPropagation();
-          onOpenRaw(e);
-        }}
-        variant="custom"
-        size="sm"
-        className="bg-light-hover dark:bg-dark-hover hover:bg-light-surface dark:hover:bg-dark-surface"
-        label="Open Raw"
-      />
       <IconButton
         icon={<Pencil size={16} />}
         onClick={(e: React.MouseEvent) => {

--- a/client/src/components/snippets/share/SharedSnippetView.tsx
+++ b/client/src/components/snippets/share/SharedSnippetView.tsx
@@ -98,7 +98,7 @@ const SharedSnippetView: React.FC = () => {
   return (
     <div className="min-h-screen bg-light-bg dark:bg-dark-bg text-light-text dark:text-dark-text p-8">
       <div className="max-w-4xl mx-auto">
-        <FullCodeView snippet={snippet} />
+        <FullCodeView snippet={snippet} isPublicView={true} />
       </div>
     </div>
   );

--- a/client/src/components/snippets/view/FullCodeView.tsx
+++ b/client/src/components/snippets/view/FullCodeView.tsx
@@ -14,6 +14,7 @@ interface FullCodeViewProps {
   showLineNumbers?: boolean;
   className?: string;
   isModal?: boolean;
+  isPublicView?: boolean;
 }
 
 export const FullCodeView: React.FC<FullCodeViewProps> = ({
@@ -22,7 +23,8 @@ export const FullCodeView: React.FC<FullCodeViewProps> = ({
   onCategoryClick,
   showLineNumbers = true,
   className = '',
-  isModal = false
+  isModal = false,
+  isPublicView = false
 }) => {
   const handleCategoryClick = (e: React.MouseEvent, category: string) => {
     e.preventDefault();
@@ -108,6 +110,9 @@ export const FullCodeView: React.FC<FullCodeViewProps> = ({
                 code={fragment.code}
                 language={fragment.language}
                 showLineNumbers={showLineNumbers}
+                isPublicView={isPublicView}
+                snippetId={snippet.id}
+                fragmentId={fragment.id}
               />
             </div>
           ))}

--- a/client/src/components/snippets/view/SnippetModal.tsx
+++ b/client/src/components/snippets/view/SnippetModal.tsx
@@ -9,6 +9,7 @@ export interface SnippetModalProps {
   onClose: () => void;
   onCategoryClick: (category: string) => void;
   showLineNumbers: boolean;
+  isPublicView: boolean;
 }
 
 const SnippetModal: React.FC<SnippetModalProps> = ({
@@ -17,6 +18,7 @@ const SnippetModal: React.FC<SnippetModalProps> = ({
   onClose,
   onCategoryClick,
   showLineNumbers,
+  isPublicView
 }) => {
   if (!snippet) return null;
 
@@ -40,6 +42,7 @@ const SnippetModal: React.FC<SnippetModalProps> = ({
         showLineNumbers={showLineNumbers}
         onCategoryClick={() => handleCategoryClick}
         isModal={true}
+        isPublicView={isPublicView}
       />
     </Modal>
   );

--- a/client/src/components/snippets/view/common/BaseSnippetStorage.tsx
+++ b/client/src/components/snippets/view/common/BaseSnippetStorage.tsx
@@ -210,6 +210,7 @@ const BaseSnippetStorage: React.FC<BaseSnippetStorageProps> = ({
         onClose={closeSnippet}
         onCategoryClick={handleCategoryClick}
         showLineNumbers={showLineNumbers}
+        isPublicView={isPublicView}
       />
     </div>
   );

--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -30,6 +30,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   useEffect(() => {
     const handleAuthError = () => {
       localStorage.removeItem('token');
+      document.cookie = 'bytestash_token=; path=/; max-age=0';
       setIsAuthenticated(false);
       setUser(null);
     };
@@ -63,12 +64,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
               setUser(response.user);
             } else {
               localStorage.removeItem('token');
+              document.cookie = 'bytestash_token=; path=/; max-age=0';
             }
           }
         }
       } catch (error) {
         console.error('Auth initialization error:', error);
         localStorage.removeItem('token');
+        document.cookie = 'bytestash_token=; path=/; max-age=0';
       } finally {
         setIsLoading(false);
       }
@@ -79,12 +82,16 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   const login = (token: string, userData: User | null) => {
     localStorage.setItem('token', token);
+    // Also set as httpOnly cookie for direct browser API access
+    document.cookie = `bytestash_token=${token}; path=/; max-age=86400; SameSite=Lax`;
     setIsAuthenticated(true);
     setUser(userData);
   };
 
   const logout = () => {
     localStorage.removeItem('token');
+    // Clear the cookie as well
+    document.cookie = 'bytestash_token=; path=/; max-age=0';
     setIsAuthenticated(false);
     setUser(null);
     addToast('Successfully logged out.', 'info');

--- a/package-lock.json
+++ b/package-lock.json
@@ -2068,6 +2068,13 @@
         "win32"
       ]
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
@@ -2569,7 +2576,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -2579,7 +2585,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/array-flatten": {
@@ -3552,6 +3557,28 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -9884,6 +9911,30 @@
         "url": "https://opencollective.com/svgo"
       }
     },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.24.0.tgz",
+      "integrity": "sha512-okwN8vf14TOgBTUyGgCXEAoHnrwwp/042dC00B3kPu2OAe9zD75BtSbLlgAK1Y5e3csJhs+AdnIxJYZN9uvptg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.14",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.14.tgz",
@@ -10724,6 +10775,20 @@
         "node": ">= 14"
       }
     },
+    "node_modules/yamljs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
+      "integrity": "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "glob": "^7.0.5"
+      },
+      "bin": {
+        "json2yaml": "bin/json2yaml",
+        "yaml2json": "bin/yaml2json"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -10784,13 +10849,16 @@
         "bcrypt": "^5.1.1",
         "better-sqlite3": "^11.5.0",
         "body-parser": "^1.20.3",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.21.1",
         "jsonwebtoken": "^9.0.2",
         "multer": "^1.4.5-lts.1",
         "openai": "^4.67.3",
-        "openid-client": "^6.1.3"
+        "openid-client": "^6.1.3",
+        "swagger-ui-express": "^5.0.1",
+        "yamljs": "^0.3.0"
       },
       "devDependencies": {
         "jest": "^29.7.0",

--- a/server/package.json
+++ b/server/package.json
@@ -15,6 +15,7 @@
     "bcrypt": "^5.1.1",
     "better-sqlite3": "^11.5.0",
     "body-parser": "^1.20.3",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.21.1",

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import cookieParser from 'cookie-parser';
 import { initializeDatabase, shutdownDatabase } from './config/database.js';
 import snippetRoutes from './routes/snippetRoutes.js';
 import authRoutes from './routes/authRoutes.js';
@@ -21,6 +22,7 @@ const app = express();
 const PORT = 5000;
 
 app.use(express.json());
+app.use(cookieParser());
 app.set('trust proxy', true);
 
 const __filename = fileURLToPath(import.meta.url);

--- a/server/src/middleware/auth.js
+++ b/server/src/middleware/auth.js
@@ -53,8 +53,14 @@ const authenticateToken = async (req, res, next) => {
     }
   }
 
+  // Try to get token from header first (for API calls)
   const authHeader = req.headers['bytestashauth'];
-  const token = authHeader && authHeader.split(' ')[1];
+  let token = authHeader && authHeader.split(' ')[1];
+
+  // If no header token, try to get from cookie (for browser access)
+  if (!token && req.cookies) {
+    token = req.cookies.bytestash_token;
+  }
 
   if (!token) {
     return res.status(401).json({ error: 'Authentication required' });

--- a/server/src/routes/publicRoutes.js
+++ b/server/src/routes/publicRoutes.js
@@ -14,6 +14,24 @@ router.get('/', async (req, res) => {
   }
 });
 
+// Raw public snippet endpoint for plain text access
+router.get('/:id/raw', async (req, res) => {
+  try {
+    const snippet = await snippetService.findById(req.params.id);
+    if (!snippet) {
+      res.status(404).send('Snippet not found');
+    } else {
+      // Join all fragment code with newlines
+      const content = snippet.fragments.map(fragment => fragment.code).join('\n\n');
+      res.set('Content-Type', 'text/plain; charset=utf-8');
+      res.send(content);
+    }
+  } catch (error) {
+    Logger.error('Error in GET /public/snippets/:id/raw:', error);
+    res.status(500).send('Internal server error');
+  }
+});
+
 router.get('/:id', async (req, res) => {
   try {
     const snippet = await snippetService.findById(req.params.id);

--- a/server/src/routes/publicRoutes.js
+++ b/server/src/routes/publicRoutes.js
@@ -15,14 +15,14 @@ router.get('/', async (req, res) => {
 });
 
 // Raw public snippet endpoint for plain text access
-router.get('/:id/raw', async (req, res) => {
+router.get('/:id/:fragmentId/raw', async (req, res) => {
   try {
-    const snippet = await snippetService.findById(req.params.id);
+    const { id, fragmentId } = req.params;
+    const snippet = await snippetService.findById(id);
     if (!snippet) {
       res.status(404).send('Snippet not found');
     } else {
-      // Join all fragment code with newlines
-      const content = snippet.fragments.map(fragment => fragment.code).join('\n\n');
+      const content = snippet.fragments.find(fragment => fragment.id === fragmentId).code;
       res.set('Content-Type', 'text/plain; charset=utf-8');
       res.send(content);
     }

--- a/server/src/routes/publicRoutes.js
+++ b/server/src/routes/publicRoutes.js
@@ -22,9 +22,13 @@ router.get('/:id/:fragmentId/raw', async (req, res) => {
     if (!snippet) {
       res.status(404).send('Snippet not found');
     } else {
-      const content = snippet.fragments.find(fragment => fragment.id === fragmentId).code;
-      res.set('Content-Type', 'text/plain; charset=utf-8');
-      res.send(content);
+      const fragment = snippet.fragments.find(fragment => fragment.id === parseInt(fragmentId));
+      if (!fragment) {
+        res.status(404).send('Fragment not found');
+      } else {
+        res.set('Content-Type', 'text/plain; charset=utf-8');
+        res.send(fragment.code);
+      }
     }
   } catch (error) {
     Logger.error('Error in GET /public/snippets/:id/raw:', error);

--- a/server/src/routes/snippetRoutes.js
+++ b/server/src/routes/snippetRoutes.js
@@ -58,14 +58,14 @@ router.put('/:id', async (req, res) => {
 });
 
 // Raw snippet endpoint for plain text access
-router.get('/:id/raw', async (req, res) => {
+router.get('/:id/:fragmentId/raw', async (req, res) => {
   try {
-    const snippet = await snippetService.findById(req.params.id, req.user.id);
+    const { id, fragmentId } = req.params;
+    const snippet = await snippetService.findById(id, req.user.id);
     if (!snippet) {
       res.status(404).send('Snippet not found');
     } else {
-      // Join all fragment code with newlines
-      const content = snippet.fragments.map(fragment => fragment.code).join('\n\n');
+      const content = snippet.fragments.find(fragment => fragment.id === fragmentId).code;
       res.set('Content-Type', 'text/plain; charset=utf-8');
       res.send(content);
     }

--- a/server/src/routes/snippetRoutes.js
+++ b/server/src/routes/snippetRoutes.js
@@ -65,9 +65,13 @@ router.get('/:id/:fragmentId/raw', async (req, res) => {
     if (!snippet) {
       res.status(404).send('Snippet not found');
     } else {
-      const content = snippet.fragments.find(fragment => fragment.id === fragmentId).code;
-      res.set('Content-Type', 'text/plain; charset=utf-8');
-      res.send(content);
+      const fragment = snippet.fragments.find(fragment => fragment.id === parseInt(fragmentId));
+      if (!fragment) {
+        res.status(404).send('Fragment not found');
+      } else {
+        res.set('Content-Type', 'text/plain; charset=utf-8');
+        res.send(fragment.code);
+      }
     }
   } catch (error) {
     Logger.error('Error in GET /snippets/:id/raw:', error);

--- a/server/src/routes/snippetRoutes.js
+++ b/server/src/routes/snippetRoutes.js
@@ -57,6 +57,24 @@ router.put('/:id', async (req, res) => {
   }
 });
 
+// Raw snippet endpoint for plain text access
+router.get('/:id/raw', async (req, res) => {
+  try {
+    const snippet = await snippetService.findById(req.params.id, req.user.id);
+    if (!snippet) {
+      res.status(404).send('Snippet not found');
+    } else {
+      // Join all fragment code with newlines
+      const content = snippet.fragments.map(fragment => fragment.code).join('\n\n');
+      res.set('Content-Type', 'text/plain; charset=utf-8');
+      res.send(content);
+    }
+  } catch (error) {
+    Logger.error('Error in GET /snippets/:id/raw:', error);
+    res.status(500).send('Internal server error');
+  }
+});
+
 router.get('/:id', async (req, res) => {
   try {
     const snippet = await snippetService.findById(req.params.id, req.user.id);


### PR DESCRIPTION
This PR adds a raw button to each individual fragment. This works for both authenticated and public snippets. This also includes some improvements to the backend authentication, allowing cookies to be used as authentication which should allow for better direct API access if required.

Closes #181 