### PR TITLE
feat: complete recycle bin feature with backend and frontend integration

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,6 +14,7 @@ import SharedSnippetView from './components/snippets/share/SharedSnippetView';
 import SnippetPage from './components/snippets/view/SnippetPage';
 import PublicSnippetStorage from './components/snippets/view/public/PublicSnippetStorage';
 import EmbedView from './components/snippets/embed/EmbedView';
+import RecycleSnippetStorage from './components/snippets/view/recycle/RecycleSnippetStorage';
 
 const AuthenticatedApp: React.FC = () => {
   const { isAuthenticated, isLoading } = useAuth();
@@ -71,6 +72,7 @@ const App: React.FC = () => {
                 <Route path={ROUTES.AUTH_CALLBACK} element={<OIDCCallback />} />
                 <Route path={ROUTES.SHARED_SNIPPET} element={<SharedSnippetView />} />
                 <Route path={ROUTES.PUBLIC_SNIPPETS} element={<PublicSnippetStorage />} />
+                <Route path={ROUTES.RECYCLE} element={<RecycleSnippetStorage />} />
                 <Route path={ROUTES.EMBED} element={<EmbedViewWrapper />} />
                 <Route path={ROUTES.SNIPPET} element={<SnippetPage />} />
                 <Route path={ROUTES.HOME} element={<AuthenticatedApp />} />

--- a/client/src/components/editor/PreviewCodeBlock.tsx
+++ b/client/src/components/editor/PreviewCodeBlock.tsx
@@ -13,6 +13,7 @@ interface PreviewCodeBlockProps {
   previewLines?: number;
   showLineNumbers?: boolean;
   isPublicView?: boolean;
+  isRecycleView?: boolean;
   snippetId?: string;
   fragmentId?: string;
 }
@@ -23,6 +24,7 @@ export const PreviewCodeBlock: React.FC<PreviewCodeBlockProps> = ({
   previewLines = 4,
   showLineNumbers = true,
   isPublicView,
+  isRecycleView,
   snippetId,
   fragmentId
 }) => {
@@ -150,7 +152,7 @@ export const PreviewCodeBlock: React.FC<PreviewCodeBlockProps> = ({
         />
 
         <CopyButton text={code} />
-        {isPublicView !== undefined && snippetId !== undefined && fragmentId !== undefined && (
+        {!isRecycleView && isPublicView !== undefined && snippetId !== undefined && fragmentId !== undefined && (
           <RawButton
             isPublicView={isPublicView}
             snippetId={snippetId}

--- a/client/src/components/search/SearchAndFilter.tsx
+++ b/client/src/components/search/SearchAndFilter.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { ChevronDown, Grid, List, Settings, Plus } from 'lucide-react';
+import { ChevronDown, Grid, List, Settings, Plus, Trash } from 'lucide-react';
 import { SearchBar } from './SearchBar';
 import { IconButton } from '../common/buttons/IconButton';
+import { useNavigate } from 'react-router-dom';
 
 export type SortOrder = 'newest' | 'oldest' | 'alpha-asc' | 'alpha-desc';
 
@@ -28,6 +29,7 @@ export interface SearchAndFilterProps {
   selectedCategories: string[];
   onCategoryClick: (category: string) => void;
   hideNewSnippet?: boolean;
+  hideRecycleBin?: boolean;
 }
 
 export const SearchAndFilter: React.FC<SearchAndFilterProps> = ({ 
@@ -45,8 +47,10 @@ export const SearchAndFilter: React.FC<SearchAndFilterProps> = ({
   allCategories,
   selectedCategories,
   onCategoryClick,
-  hideNewSnippet = false
+  hideNewSnippet = false,
+  hideRecycleBin = false
 }) => {
+  const navigate = useNavigate();
   return (
     <div className="flex flex-wrap items-center gap-2 mb-6">
       <SearchBar
@@ -114,16 +118,27 @@ export const SearchAndFilter: React.FC<SearchAndFilterProps> = ({
           className="h-10 px-4"
           label="Open settings"
         />
-        {!hideNewSnippet && (
+      {!hideNewSnippet && (
+        <div className="flex gap-2">
+          {!hideRecycleBin && (
+            <IconButton
+              icon={<Plus size={20} />}
+              label="New Snippet"
+              onClick={openNewSnippetModal}
+              variant="action"
+              className="h-10 pl-2 pr-4"
+              showLabel
+            />
+          )}
           <IconButton
-            icon={<Plus size={20} />}
-            label="New Snippet"
-            onClick={openNewSnippetModal}
-            variant="action"
-            className="h-10 pl-2 pr-4"
-            showLabel={true}
+            icon={<Trash size={20} />}
+            onClick={() => navigate('/recycle/snippets')}
+            variant={location.pathname === '/recycle/snippets' ? 'primary' : 'secondary'}
+            className="h-10 px-4"
+            label="Recycle Bin"
           />
-        )}
+        </div>
+      )}
       </div>
     </div>
   );

--- a/client/src/components/snippets/list/SnippetList.tsx
+++ b/client/src/components/snippets/list/SnippetList.tsx
@@ -7,6 +7,7 @@ export interface SnippetListProps {
   viewMode: 'grid' | 'list';
   onOpen: (snippet: Snippet) => void;
   onDelete: (id: string) => void;
+  onRestore: (id: string) => void;
   onEdit: (snippet: Snippet) => void;
   onShare: (snippet: Snippet) => void;
   onDuplicate: (snippet: Snippet) => void;
@@ -18,6 +19,7 @@ export interface SnippetListProps {
   expandCategories: boolean;
   showLineNumbers: boolean;
   isPublicView: boolean;
+  isRecycleView: boolean;
   isAuthenticated: boolean;
 }
 
@@ -25,7 +27,8 @@ const SnippetList: React.FC<SnippetListProps> = ({
   snippets, 
   viewMode, 
   onOpen, 
-  onDelete, 
+  onDelete,
+  onRestore, 
   onEdit,
   onShare,
   onDuplicate,
@@ -37,6 +40,7 @@ const SnippetList: React.FC<SnippetListProps> = ({
   expandCategories,
   showLineNumbers,
   isPublicView,
+  isRecycleView,
   isAuthenticated
 }) => {
   if (snippets.length === 0) {
@@ -61,6 +65,7 @@ const SnippetList: React.FC<SnippetListProps> = ({
           viewMode={viewMode}
           onOpen={onOpen}
           onDelete={onDelete}
+          onRestore={onRestore}
           onEdit={onEdit}
           onShare={onShare}
           onDuplicate={onDuplicate}
@@ -72,6 +77,7 @@ const SnippetList: React.FC<SnippetListProps> = ({
           expandCategories={expandCategories}
           showLineNumbers={showLineNumbers}
           isPublicView={isPublicView}
+          isRecycleView={isRecycleView}
           isAuthenticated={isAuthenticated}
         />
       ))}

--- a/client/src/components/snippets/list/SnippetRecycleCardMenu.tsx
+++ b/client/src/components/snippets/list/SnippetRecycleCardMenu.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import {Trash2,ArchiveRestore } from 'lucide-react';
+import { IconButton } from '../../common/buttons/IconButton';
+
+interface SnippetRecycleCardMenuProps {
+  onRestore: (e: React.MouseEvent) => void;
+  onDelete: (e: React.MouseEvent) => void;
+}
+
+const SnippetRecycleCardMenu: React.FC<SnippetRecycleCardMenuProps> = ({
+  onDelete,
+  onRestore,
+}) => {
+  return (
+    <div className="top-4 right-4 flex items-center gap-1">
+        <IconButton
+        icon={<ArchiveRestore size={16} className="hover:text-yellow-500" />}
+        onClick={(e: React.MouseEvent) => {
+          e.stopPropagation();
+          onRestore(e);
+        }}
+        variant="custom"
+        size="sm"
+        className="bg-light-hover dark:bg-dark-hover hover:bg-light-hover-more dark:hover:bg-dark-hover-more"
+        label="Restore snippet"
+      />
+      <IconButton
+        icon={<Trash2 size={17} className="hover:text-red-500" />}
+        onClick={(e: React.MouseEvent) => {
+          e.stopPropagation();
+          onDelete(e);
+        }}
+        variant="custom"
+        size="sm"
+        className="bg-light-hover dark:bg-dark-hover hover:bg-light-hover-more dark:hover:bg-dark-hover-more"
+        label="Restore snippet"
+      />
+    </div>
+  );
+};
+
+export default SnippetRecycleCardMenu;

--- a/client/src/components/snippets/list/SnippetRecycleCardMenu.tsx
+++ b/client/src/components/snippets/list/SnippetRecycleCardMenu.tsx
@@ -33,7 +33,7 @@ const SnippetRecycleCardMenu: React.FC<SnippetRecycleCardMenuProps> = ({
         variant="custom"
         size="sm"
         className="bg-light-hover dark:bg-dark-hover hover:bg-light-hover-more dark:hover:bg-dark-hover-more"
-        label="Restore snippet"
+        label="Delete snippet"
       />
     </div>
   );

--- a/client/src/components/snippets/view/SnippetModal.tsx
+++ b/client/src/components/snippets/view/SnippetModal.tsx
@@ -13,6 +13,7 @@ export interface SnippetModalProps {
   onCategoryClick: (category: string) => void;
   showLineNumbers: boolean;
   isPublicView: boolean;
+  isRecycleView?: boolean;
 }
 
 const SnippetModal: React.FC<SnippetModalProps> = ({
@@ -23,7 +24,8 @@ const SnippetModal: React.FC<SnippetModalProps> = ({
   onDelete,
   onCategoryClick,
   showLineNumbers,
-  isPublicView
+  isPublicView,
+  isRecycleView
 }) => {
   if (!snippet) return null;
 
@@ -85,9 +87,13 @@ const SnippetModal: React.FC<SnippetModalProps> = ({
         isOpen={isDeleteModalOpen}
         onClose={cancelDeleteSnippet}
         onConfirm={confirmDeleteSnippet}
-        title="Confirm Deletion"
-        message={`Are you sure you want to delete "${snippetToDelete?.title || snippet?.title}"? This action cannot be undone.`}
-        confirmLabel="Delete"
+         title={isRecycleView ? "Confirm Deletion" : "Move to Recycle Bin"}
+        message={
+          isRecycleView
+            ? `Are you sure you want to permanently delete "${snippet.title}"? This action cannot be undone.`
+            : `Are you sure you want to move "${snippet.title}" to the Recycle Bin?`
+        }
+        confirmLabel={isRecycleView ? "Delete Permanently" : "Move to Recycle Bin"}
         cancelLabel="Cancel"
         variant="danger"
       />

--- a/client/src/components/snippets/view/SnippetStorage.tsx
+++ b/client/src/components/snippets/view/SnippetStorage.tsx
@@ -115,6 +115,7 @@ const SnippetStorage: React.FC = () => {
         onDuplicate={handleDuplicate}
         headerRight={<UserDropdown />}
         isPublicView={false}
+        isRecycleView={false}
         isAuthenticated={isAuthenticated}
       />
 

--- a/client/src/components/snippets/view/common/BaseSnippetStorage.tsx
+++ b/client/src/components/snippets/view/common/BaseSnippetStorage.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useMemo, useCallback } from 'react';
-import { Loader2 } from 'lucide-react';
+import { ArrowLeftToLine, Loader2 } from 'lucide-react';
 import { Snippet } from '../../../../types/snippets';
 import { getLanguageLabel } from '../../../../utils/language/languageUtils';
 import { SearchAndFilter } from '../../../search/SearchAndFilter';
 import SnippetList from '../../list/SnippetList';
 import SnippetModal from '../SnippetModal';
 import { PageContainer } from '../../../common/layout/PageContainer';
+import { useNavigate } from 'react-router-dom';
 import StorageHeader from './StorageHeader';
 
 interface BaseSnippetStorageProps {
@@ -23,11 +24,13 @@ interface BaseSnippetStorageProps {
   onSettingsOpen: () => void;
   onNewSnippet: () => void;
   onDelete?: (id: string) => Promise<void>;
+  onRestore?: (id: string) => Promise<void>;
   onEdit?: (snippet: Snippet) => void;
   onShare?: (snippet: Snippet) => void;
   onDuplicate?: (snippet: Snippet) => void;
   headerRight: React.ReactNode;
   isPublicView: boolean;
+  isRecycleView: boolean;
   isAuthenticated: boolean;
 }
 
@@ -46,11 +49,13 @@ const BaseSnippetStorage: React.FC<BaseSnippetStorageProps> = ({
   onSettingsOpen,
   onNewSnippet,
   onDelete,
+  onRestore,
   onEdit,
   onShare,
   onDuplicate,
   headerRight,
   isPublicView,
+  isRecycleView,
   isAuthenticated
 }) => {
   const [searchTerm, setSearchTerm] = useState('');
@@ -58,6 +63,7 @@ const BaseSnippetStorage: React.FC<BaseSnippetStorageProps> = ({
   const [selectedSnippet, setSelectedSnippet] = useState<Snippet | null>(null);
   const [sortOrder, setSortOrder] = useState<'newest' | 'oldest' | 'alpha-asc' | 'alpha-desc'>('newest');
   const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
+  const navigate = useNavigate();
 
   const handleSearchTermChange = useCallback((term: string) => {
     setSearchTerm(term);
@@ -167,7 +173,28 @@ const BaseSnippetStorage: React.FC<BaseSnippetStorageProps> = ({
         selectedCategories={selectedCategories}
         onCategoryClick={handleCategoryClick}
         hideNewSnippet={isPublicView}
+        hideRecycleBin={isRecycleView}
       />
+
+      {isRecycleView && (
+        <div className="mb-6 space-y-3">
+          <button 
+            onClick={() => navigate('/')} 
+            className="flex items-center gap-2 text-sm font-medium text-white hover:underline"
+          >
+            <ArrowLeftToLine size={18} /> Back to Snippets
+          </button>
+
+          <div className="text-sm text-light-text-primary dark:text-dark-text-secondary">
+            <h1 className="text-2xl font-semibold text-white">Recycle Bin</h1>
+            <p className="text-sm">
+              Snippets in the recycle bin will be permanently deleted after 30 days.
+            </p>
+          </div>
+        </div>
+      )}
+
+
 
       {selectedCategories.length > 0 && (
         <div className="flex flex-wrap gap-2 mb-4 items-center">
@@ -190,6 +217,7 @@ const BaseSnippetStorage: React.FC<BaseSnippetStorageProps> = ({
         viewMode={viewMode}
         onOpen={openSnippet}
         onDelete={onDelete || (() => Promise.resolve())}
+        onRestore={onRestore || (() => Promise.resolve())} 
         onEdit={onEdit || (() => {})}
         onCategoryClick={handleCategoryClick}
         onShare={onShare || (() => {})}
@@ -201,6 +229,7 @@ const BaseSnippetStorage: React.FC<BaseSnippetStorageProps> = ({
         expandCategories={expandCategories}
         showLineNumbers={showLineNumbers}
         isPublicView={isPublicView}
+        isRecycleView={isRecycleView}
         isAuthenticated={isAuthenticated}
       />
 
@@ -213,6 +242,7 @@ const BaseSnippetStorage: React.FC<BaseSnippetStorageProps> = ({
         onCategoryClick={handleCategoryClick}
         showLineNumbers={showLineNumbers}
         isPublicView={isPublicView}
+        isRecycleView={false}
       />
     </div>
   );

--- a/client/src/components/snippets/view/recycle/RecycleSnippetStorage.tsx
+++ b/client/src/components/snippets/view/recycle/RecycleSnippetStorage.tsx
@@ -1,17 +1,16 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { useSettings } from '../../../../hooks/useSettings';
 import { useToast } from '../../../../hooks/useToast';
 import { useAuth } from '../../../../hooks/useAuth';
 import { initializeMonaco } from '../../../../utils/language/languageUtils';
 import SettingsModal from '../../../settings/SettingsModal';
 import BaseSnippetStorage from '../common/BaseSnippetStorage';
-import { fetchPublicSnippets } from '../../../../utils/api/snippets';
+import { getRecycleSnippets } from '../../../../utils/api/snippets';
+import { useSnippets } from '../../../../hooks/useSnippets';
 import { Snippet } from '../../../../types/snippets';
 import { UserDropdown } from '../../../auth/UserDropdown';
-import { ROUTES } from '../../../../constants/routes';
 
-const PublicSnippetStorage: React.FC = () => {
+const RecycleSnippetStorage: React.FC = () => {
   const { 
     viewMode, setViewMode, compactView, showCodePreview, 
     previewLines, includeCodeInSearch, updateSettings,
@@ -21,10 +20,10 @@ const PublicSnippetStorage: React.FC = () => {
 
   const { isAuthenticated } = useAuth();
   const { addToast } = useToast();
-  const navigate = useNavigate();
   const [snippets, setSnippets] = useState<Snippet[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
+  const { permanentDeleteSnippet, restoreSnippet } = useSnippets();
 
   useEffect(() => {
     initializeMonaco();
@@ -33,38 +32,13 @@ const PublicSnippetStorage: React.FC = () => {
 
   const loadSnippets = async () => {
     try {
-      const fetchedSnippets = await fetchPublicSnippets();
+      const fetchedSnippets = await getRecycleSnippets();
       setSnippets(fetchedSnippets);
     } catch (error) {
-      console.error('Failed to load public snippets:', error);
-      addToast('Failed to load public snippets', 'error');
+      console.error('Failed to load recycled snippets:', error);
+      addToast('Failed to load recycled snippets', 'error');
     } finally {
       setIsLoading(false);
-    }
-  };
-
-  const handleDuplicate = async (snippet: Snippet) => {
-    if (!isAuthenticated) {
-      addToast('Please sign in to add this snippet to your collection', 'info');
-      navigate(ROUTES.LOGIN);
-      return;
-    }
-
-    try {
-      const duplicatedSnippet: Omit<Snippet, 'id' | 'updated_at' | 'share_count' | 'username'> = {
-        title: `${snippet.title}`,
-        description: snippet.description,
-        categories: [...snippet.categories],
-        fragments: snippet.fragments.map(f => ({ ...f })),
-        is_public: 0
-      };
-      
-      const { createSnippet } = await import('../../../../utils/api/snippets');
-      await createSnippet(duplicatedSnippet);
-      addToast('Snippet added to your collection', 'success');
-    } catch (error) {
-      console.error('Failed to duplicate snippet:', error);
-      addToast('Failed to add snippet to your collection', 'error');
     }
   };
 
@@ -80,14 +54,18 @@ const PublicSnippetStorage: React.FC = () => {
         previewLines={previewLines}
         includeCodeInSearch={includeCodeInSearch}
         showCategories={showCategories}
+        onDelete={async (id) => {
+          await permanentDeleteSnippet(id);
+          loadSnippets(); // refresh after delete
+        }}
+        onRestore={restoreSnippet}
         expandCategories={expandCategories}
         showLineNumbers={showLineNumbers}
         onSettingsOpen={() => setIsSettingsModalOpen(true)}
         onNewSnippet={() => null}
-        onDuplicate={handleDuplicate}
         headerRight={<UserDropdown />}
-        isPublicView={true}
-        isRecycleView={false}
+        isPublicView={false}
+        isRecycleView={true}
         isAuthenticated={isAuthenticated}
       />
 
@@ -114,4 +92,4 @@ const PublicSnippetStorage: React.FC = () => {
   );
 };
 
-export default PublicSnippetStorage;
+export default RecycleSnippetStorage;

--- a/client/src/constants/routes.ts
+++ b/client/src/constants/routes.ts
@@ -6,5 +6,6 @@ export const ROUTES = {
   REGISTER: '/register',
   PUBLIC_SNIPPETS: '/public/snippets',
   AUTH_CALLBACK: '/auth/callback',
-  EMBED: '/embed/:shareId'
+  EMBED: '/embed/:shareId',
+  RECYCLE: '/recycle/snippets',
 } as const;

--- a/client/src/service/snippetService.ts
+++ b/client/src/service/snippetService.ts
@@ -21,5 +21,17 @@ export const snippetService = {
 
   async deleteSnippet(id: string): Promise<void> {
     return apiClient.delete(`${API_ENDPOINTS.SNIPPETS}/${id}`, { requiresAuth: true });
+  },
+
+  async getRecycleSnippets(): Promise<Snippet[]> {
+    return apiClient.get(`${API_ENDPOINTS.SNIPPETS}/recycled`, { requiresAuth: true });
+  },
+
+  async restoreSnippet(id: string): Promise<void> {
+    return apiClient.patch(`${API_ENDPOINTS.SNIPPETS}/${id}/restore`, {}, { requiresAuth: true });
+  },
+
+  async moveToRecycleBin(id: string): Promise<void> {
+    return apiClient.patch(`${API_ENDPOINTS.SNIPPETS}/${id}/recycle`, {}, { requiresAuth: true });
   }
 };

--- a/client/src/types/snippets.ts
+++ b/client/src/types/snippets.ts
@@ -11,6 +11,7 @@ export interface Snippet {
   title: string;
   description: string;
   updated_at: string;
+  expiry_date?: string;
   categories: string[];
   fragments: CodeFragment[];
   share_count?: number;

--- a/client/src/utils/api/apiClient.ts
+++ b/client/src/utils/api/apiClient.ts
@@ -83,6 +83,13 @@ export class ApiClient {
       body: JSON.stringify(data),
     });
   }
+  async patch<T>(endpoint: string, data: any, options: RequestOptions = {}): Promise<T> {
+    return this.request<T>(endpoint, {
+      ...options,
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    });
+  }
 
   async delete<T>(endpoint: string, options: RequestOptions = {}): Promise<T> {
     return this.request<T>(endpoint, { ...options, method: 'DELETE' });

--- a/client/src/utils/api/snippets.ts
+++ b/client/src/utils/api/snippets.ts
@@ -76,3 +76,30 @@ export const getPublicSnippetById = async (id: string): Promise<Snippet> => {
     throw error;
   }
 };
+
+export const getRecycleSnippets = async (): Promise<Snippet[]> => {
+  try {
+    return await snippetService.getRecycleSnippets();
+  } catch (error) {
+    console.error('Error fetching recycled snippets:', error);
+    throw error;
+  }
+};
+
+export const restoreSnippetById = async (id: string): Promise<void> => {
+  try {
+    await snippetService.restoreSnippet(id);
+  } catch (error) {
+    console.error('Error restoring snippet:', error);
+    throw error;
+  }
+};
+
+export const moveToRecycleBin = async (id: string): Promise<void> => {
+  try {
+    await snippetService.moveToRecycleBin(id);
+  } catch (error) {
+    console.error('Error moving snippet to recycle bin:', error);
+    throw error;
+  }
+};

--- a/server/src/config/database.js
+++ b/server/src/config/database.js
@@ -9,6 +9,7 @@ import { up_v1_5_0_oidc } from './migrations/20241120-migration.js';
 import { fileURLToPath } from 'url';
 import { up_v1_5_0_usernames } from './migrations/20241121-migration.js';
 import { up_v1_5_1_api_keys } from './migrations/20241122-migration.js';
+import { up_v1_6_0_snippet_expiry } from './migrations/20250601-migration.js';  
 import path from 'path';
 let db = null;
 let checkpointInterval = null;
@@ -106,13 +107,14 @@ function initializeDatabase() {
       createInitialSchema(db);
     } else {
       Logger.debug('Database file exists, checking for needed migrations...');
-
       up_v1_4_0(db);
       up_v1_5_0(db);
       up_v1_5_0_public(db);
       up_v1_5_0_oidc(db);
       up_v1_5_0_usernames(db);
       up_v1_5_1_api_keys(db);
+      up_v1_6_0_snippet_expiry(db);
+      Logger.debug('All migrations applied successfully');
     }
 
     startCheckpointInterval();

--- a/server/src/config/migrations/20250601-migration.js
+++ b/server/src/config/migrations/20250601-migration.js
@@ -1,0 +1,40 @@
+import Logger from '../../logger.js';
+
+function needsMigration(db) {
+  try {
+    const hasExpiryColumn = db
+      .prepare(`
+        SELECT COUNT(*) as count 
+        FROM pragma_table_info('snippets') 
+        WHERE name = 'expiry_date'
+      `)
+      .get();
+
+    return hasExpiryColumn.count === 0;
+  } catch (error) {
+    Logger.error('v1.6.0-snippet-expiry - Error checking migration status:', error);
+    throw error;
+  }
+}
+
+async function up_v1_6_0_snippet_expiry(db) {
+  if (!needsMigration(db)) {
+    Logger.debug('v1.6.0-snippet-expiry - Migration not needed');
+    return;
+  }
+
+  Logger.debug('v1.6.0-snippet-expiry - Starting migration...');
+
+  try {
+    db.exec(`
+      ALTER TABLE snippets ADD COLUMN expiry_date DATETIME DEFAULT NULL;
+    `);
+
+    Logger.debug('v1.6.0-snippet-expiry - Migration completed successfully');
+  } catch (error) {
+    Logger.error('v1.6.0-snippet-expiry - Migration failed:', error);
+    throw error;
+  }
+}
+
+export { up_v1_6_0_snippet_expiry };

--- a/server/src/config/schema/init.sql
+++ b/server/src/config/schema/init.sql
@@ -15,6 +15,7 @@ CREATE TABLE IF NOT EXISTS snippets (
     title TEXT NOT NULL,
     description TEXT,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    expiry_date DATETIME DEFAULT NULL,
     user_id INTEGER REFERENCES users (id),
     is_public BOOLEAN DEFAULT FALSE
 );

--- a/server/src/repositories/shareRepository.js
+++ b/server/src/repositories/shareRepository.js
@@ -40,7 +40,7 @@ class ShareRepository {
         FROM shared_snippets ss
         JOIN snippets s ON s.id = ss.snippet_id
         LEFT JOIN categories c ON s.id = c.snippet_id
-        WHERE ss.id = ?
+        WHERE ss.id = ? AND ss.expiry_date IS NULL
         GROUP BY s.id
       `);
 
@@ -50,7 +50,7 @@ class ShareRepository {
           datetime(ss.expires_at) < datetime('now') as expired
         FROM shared_snippets ss
         JOIN snippets s ON s.id = ss.snippet_id
-        WHERE ss.snippet_id = ? AND s.user_id = ?
+        WHERE ss.snippet_id = ? AND s.user_id = ? AND s.expiry_date IS NULL
         ORDER BY ss.created_at DESC
       `);
 

--- a/server/src/routes/snippetRoutes.js
+++ b/server/src/routes/snippetRoutes.js
@@ -38,6 +38,44 @@ router.delete('/:id', async (req, res) => {
   }
 });
 
+router.patch('/:id/restore',async (req, res) => {
+  try{
+    const result = await snippetService.restoreSnippet(req.params.id, req.user.id);
+    if (!result) {
+      res.status(404).json({ error: 'Snippet not found or not in recycle bin' });
+    } else {
+      res.json({ id: result.id });
+    }
+  } catch (error){
+    Logger.error('Error in PATCH /snippets/:id/restore:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+router.patch('/:id/recycle', async (req, res) => {
+  try {
+    const result = await snippetService.moveToRecycle(req.params.id, req.user.id);
+    if (!result) {
+      res.status(404).json({ error: 'Snippet not found or already moved to recycle bin' });
+    } else {
+      res.json({ id: result.id });
+    }
+  } catch (error) {
+    Logger.error('Error in POST /snippets/:id/recycle:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+router.get('/recycled', async (req, res) => {
+  try {
+    const recycledSnippets = await snippetService.getRecycledSnippets(req.user.id);
+    res.json(recycledSnippets);
+  } catch (error) {
+    Logger.error('Error in GET /snippets/recycled:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
 router.put('/:id', async (req, res) => {
   try {
     const updatedSnippet = await snippetService.updateSnippet(

--- a/server/src/services/snippetService.js
+++ b/server/src/services/snippetService.js
@@ -42,6 +42,49 @@ class SnippetService {
     }
   }
 
+  async moveToRecycle(id, userId) {
+    try {
+      Logger.debug('Service: Moving snippet to recycle bin:', id, 'for user:', userId);
+      const result = await snippetRepository.moveToRecycle(id, userId);
+      if (!result) {
+        Logger.warn('Service: Snippet not found or already moved to recycle bin');
+        return null;
+      }
+      Logger.debug('Service: Snippet moved to recycle bin successfully');
+      return { id: result.id };
+    } catch (error) {
+      Logger.error('Service Error - moveToRecycle:', error);
+      throw error;
+    }
+  }
+
+  async getRecycledSnippets(userId) {
+    try {
+      // Ensure expired snippets are deleted before fetching recycled snippets
+      this.deleteExpiredSnippets();
+
+      Logger.debug('Service: Getting recycled snippets for user:', userId);
+      const result = await snippetRepository.findAllDeleted(userId);
+      Logger.debug(`Service: Retrieved ${result.length} recycled snippets`);
+      return result;
+      // return {};
+    } catch (error) {
+      Logger.error('Service Error - getRecycledSnippets:', error);    
+      throw error;
+    }
+  }
+
+  async deleteExpiredSnippets() {
+    try{
+      Logger.debug('Service: Deleting expired snippets');
+       await snippetRepository.deleteExpired();
+      Logger.debug(`Service: Deleted expired snippets`);
+    } catch (error) {
+      Logger.error('Service Error - deleteExpiredSnippets:', error);
+      throw error;
+    }
+  } 
+
   async deleteSnippet(id, userId) {
     try {
       Logger.debug('Service: Deleting snippet:', id, 'for user:', userId);
@@ -50,6 +93,18 @@ class SnippetService {
       return result;
     } catch (error) {
       Logger.error('Service Error - deleteSnippet:', error);
+      throw error;
+    }
+  }
+
+  async restoreSnippet(id, userId) {
+    try {
+      Logger.debug('Service: Restoring snippet:', id, 'for user:', userId);
+      await snippetRepository.restore(id, userId);
+      Logger.debug('Service: Restore operation result:', 'Success');
+      return { id };
+    } catch (error) {
+      Logger.error('Service Error - restoreSnippet:', error);
       throw error;
     }
   }

--- a/server/src/services/snippetService.js
+++ b/server/src/services/snippetService.js
@@ -47,7 +47,7 @@ class SnippetService {
       Logger.debug('Service: Moving snippet to recycle bin:', id, 'for user:', userId);
       const result = await snippetRepository.moveToRecycle(id, userId);
       if (!result) {
-        Logger.warn('Service: Snippet not found or already moved to recycle bin');
+        Logger.debug('Service: Snippet not found or already moved to recycle bin');
         return null;
       }
       Logger.debug('Service: Snippet moved to recycle bin successfully');


### PR DESCRIPTION
feat: Implemented a recycle bin feature with backend and frontend support.

Key changes:

- Added a new recycle bin page.
- Created a migration to add an `expiry_date` column to the `snippets` table if it doesn't exist.
- Changes in frontend for modals
- Introduced three new API routes:
    - `GET api/snippets/recycled`: Retrieves all snippets in the recycle bin. Before retrieving, a function is executed to permanently delete snippets where `expiry_date` is less than or equal to the current date.
    - `PATCH api/snippets/restore`: Restores a snippet from the recycle bin by setting its `expiry_date` to NULL. Requires the snippet's ID.
    - `PATCH api/snippets/recycle`: Moves a snippet to the recycle bin by setting its `expiry_date` to the current date plus 30 days. Requires the snippet's ID.
    
    
   Demo : 
[screen-capture (1).webm](https://github.com/user-attachments/assets/3a4d9164-633d-46f6-bd67-8390a4ea3aee)
