### PR TITLE
Fix: Share Snippet feature in Browser throws an error message

### DIFF
--- a/server/src/repositories/shareRepository.js
+++ b/server/src/repositories/shareRepository.js
@@ -150,7 +150,6 @@ class ShareRepository {
       if (isNaN(snippetIdInt)) {
         throw new Error('Invalid snippet ID');
       }
-      Logger.debug(this.getSharesBySnippetIdStmt)
       return this.getSharesBySnippetIdStmt.all(snippetIdInt, userId);
     } catch (error) {
       Logger.error('Error in getSharesBySnippetId:', error);

--- a/server/src/repositories/shareRepository.js
+++ b/server/src/repositories/shareRepository.js
@@ -40,7 +40,7 @@ class ShareRepository {
         FROM shared_snippets ss
         JOIN snippets s ON s.id = ss.snippet_id
         LEFT JOIN categories c ON s.id = c.snippet_id
-        WHERE ss.id = ? AND ss.expiry_date IS NULL
+        WHERE ss.id = ? AND s.expiry_date IS NULL
         GROUP BY s.id
       `);
 
@@ -150,6 +150,7 @@ class ShareRepository {
       if (isNaN(snippetIdInt)) {
         throw new Error('Invalid snippet ID');
       }
+      Logger.debug(this.getSharesBySnippetIdStmt)
       return this.getSharesBySnippetIdStmt.all(snippetIdInt, userId);
     } catch (error) {
       Logger.error('Error in getSharesBySnippetId:', error);


### PR DESCRIPTION
## Issue Description
---

- The Share Snippet option was throwing an error in the website. Upon inspection, I realized that the SQL Command for querying the Database for Code Snippets had an error.

## Fix Description
---

- `ShareRepository.js` contains a `getShareStmt` object with an SQL command for querying shared snippets. 
- `ss.expiry_date` was replaced with `s.expiry_date` to fix the SQL command.
- The Share Snippet feature functions perfectly as intended.

> P.S.: Shoutout to the developer for such a wonderful software. I hope this minor fix helps contribute towards your goal.