### PR TITLE
Fix scrolling across code segments in Edit/Create mode

### DIFF
--- a/client/src/components/editor/CodeEditor.tsx
+++ b/client/src/components/editor/CodeEditor.tsx
@@ -135,6 +135,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
           lineDecorationsWidth: showLineNumbers ? 24 : 50,
           overviewRulerBorder: false,
           scrollbar: {
+            alwaysConsumeMouseWheel: false, // Fixes an issue where scrolling to end of code block did not allow further scrolling
             vertical: 'visible',
             horizontal: 'visible',
             verticalScrollbarSize: 12,


### PR DESCRIPTION
# Bug Description
---

- When a code snippet contains multiple code segments, and a user tries to scroll through each segment, the mouse focus is captured by the editor, and the outer view does not scroll anymore, even after the user has scrolled towards the end of the current segment.

# Fix Description
---

- Added a native property in Monaco editor which avoids consuming mouse scrolls at all times. 
- This should allow the user to scroll through each segment once the end of segment is reached.