### PR TITLE
Fix OIDC Auth Logic: Missing idP Logout logic implemented

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,6 +15,7 @@ import SnippetPage from './components/snippets/view/SnippetPage';
 import PublicSnippetStorage from './components/snippets/view/public/PublicSnippetStorage';
 import EmbedView from './components/snippets/embed/EmbedView';
 import RecycleSnippetStorage from './components/snippets/view/recycle/RecycleSnippetStorage';
+import { OIDCLogoutCallback } from './components/auth/oidc/OIDCLogoutCallback';
 
 const AuthenticatedApp: React.FC = () => {
   const { isAuthenticated, isLoading } = useAuth();
@@ -70,6 +71,7 @@ const App: React.FC = () => {
                 <Route path={ROUTES.LOGIN} element={<LoginPage />} />
                 <Route path={ROUTES.REGISTER} element={<RegisterPage />} />
                 <Route path={ROUTES.AUTH_CALLBACK} element={<OIDCCallback />} />
+                <Route path={ROUTES.LOGOUT_CALLBACK} element={<OIDCLogoutCallback />} />
                 <Route path={ROUTES.SHARED_SNIPPET} element={<SharedSnippetView />} />
                 <Route path={ROUTES.PUBLIC_SNIPPETS} element={<PublicSnippetStorage />} />
                 <Route path={ROUTES.RECYCLE} element={<RecycleSnippetStorage />} />

--- a/client/src/components/auth/oidc/OIDCLogoutCallback.tsx
+++ b/client/src/components/auth/oidc/OIDCLogoutCallback.tsx
@@ -1,0 +1,26 @@
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../../hooks/useAuth';
+import { Loader2 } from 'lucide-react';
+import { PageContainer } from '../../common/layout/PageContainer';
+
+export const OIDCLogoutCallback: React.FC = () => {
+  const navigate = useNavigate();
+  const { logout } = useAuth();
+
+  useEffect(() => {
+      logout();
+      navigate('/', { replace: true });
+  }, [logout]);
+
+  return (
+    <PageContainer>
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="flex items-center gap-3">
+          <Loader2 className="w-6 h-6 text-light-text-secondary dark:text-dark-text-secondary animate-spin" />
+          <span className="text-light-text dark:text-dark-text text-lg">Completing sign out...</span>
+        </div>
+      </div>
+    </PageContainer>
+  );
+};

--- a/client/src/constants/routes.ts
+++ b/client/src/constants/routes.ts
@@ -6,6 +6,7 @@ export const ROUTES = {
   REGISTER: '/register',
   PUBLIC_SNIPPETS: '/public/snippets',
   AUTH_CALLBACK: '/auth/callback',
+  LOGOUT_CALLBACK: '/auth/logout_callback',
   EMBED: '/embed/:shareId',
   RECYCLE: '/recycle/snippets',
 } as const;

--- a/client/src/types/auth.ts
+++ b/client/src/types/auth.ts
@@ -1,4 +1,5 @@
 export interface OIDCConfig {
   enabled: boolean;
   displayName: string;
+  logged_in: boolean;
 }


### PR DESCRIPTION
# Feature Description
--- 

- The existing OIDC performed a login based on the provider. But during logout, only the application session was invalidated. Hence, there was a vulnerability of login session persistence even after logging out.
- Hence, logout logic is implemented to safely invalidate the idP session as well as the application server session.

# Logout Flow
---

1. The user logged in via OIDC clicks on Logout.
2. The client checks if OIDC is enabled. If yes, the client sends an api request to the server for logout logic.
3. The OIDC Provider's logout URL is generated using the previously generated Token ID during login, and the session at the OIDC Provider is invalidated.
5. Logic returns to the client where the client session is invalidated.
6. The user is presenting with success message and the Login page appears.


# Considerations
---

1. The above logic only executes if the user is logged in via OIDC. Else, only the application sessions are invalidated. 