### PR TITLE
feat: export snippets as markdown with 1 file per snippet (#170)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -6,6 +6,7 @@
     "@monaco-editor/react": "^4.6.0",
     "date-fns": "^4.1.0",
     "framer-motion": "^11.11.9",
+    "jszip": "^3.10.1",
     "lucide-react": "^0.513.0",
     "monaco-editor": "^0.52.0",
     "parse-duration": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@monaco-editor/react": "^4.6.0",
         "date-fns": "^4.1.0",
         "framer-motion": "^11.11.9",
+        "jszip": "^3.10.1",
         "lucide-react": "^0.513.0",
         "monaco-editor": "^0.52.0",
         "parse-duration": "^1.1.0",
@@ -3988,6 +3989,12 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -4267,6 +4274,48 @@
         "node": ">=10"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/jwa": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
@@ -4286,6 +4335,15 @@
       "dependencies": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lilconfig": {
@@ -5577,6 +5635,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parse-duration": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-1.1.0.tgz",
@@ -6498,6 +6562,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",


### PR DESCRIPTION
**This PR adds the ability to export all selected snippets as Markdown files in a single ZIP archive, with one file per snippet, addressing [Issue #170](https://github.com/jordan-dalby/ByteStash/issues/170).**

## Feature Details
- Exports **all selected snippets at once** in a ZIP file.
- Each snippet is saved as its **own Markdown file** inside the ZIP.
- **Markdown file format includes:**
  - **Heading** – snippet title
  - **Description** – included if present
  - **Tags** – listed below the description with bullet points 
  - **Code** – wrapped in a code block with proper syntax highlighting 
- Fully integrated with **ByteStash export workflow**.

## Demo
- [Watch Demo Video](https://drive.google.com/file/d/1wJA31G4OCzRS8U221kpXbof7sUKPfUmC/view?usp=sharing) – shows batch export and ZIP download in action.

## Motivation
- Enhances the current JSON export system by allowing **direct Markdown export in a convenient ZIP**.
- Makes it easier to **share, backup, or use snippets outside ByteStash**.

## Notes
- Each snippet produces a **separate file** in the ZIP archive.
- Future improvements could include:
  - **Custom Markdown templates**
  - **Optional individual snippet downloads**

Fixes #170