### PR TITLE
fix(server): raise JSON body limit to 2mb to support fragments larger than 94kb

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -1,53 +1,65 @@
-import express from 'express';
-import cookieParser from 'cookie-parser';
-import { initializeDatabase, shutdownDatabase } from './config/database.js';
-import snippetRoutes from './routes/snippetRoutes.js';
-import authRoutes from './routes/authRoutes.js';
-import shareRoutes from './routes/shareRoutes.js';
-import publicRoutes from './routes/publicRoutes.js';
-import oidcRoutes from './routes/oidcRoutes.js';
-import embedRoutes from './routes/embedRoutes.js';
-import apiKeyRoutes from './routes/apiKeyRoutes.js';
-import apiSnippetRoutes from './routes/apiSnippetRoutes.js';
-import { authenticateToken } from './middleware/auth.js';
-import { authenticateApiKey } from './middleware/apiKeyAuth.js';
-import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
-import fs from 'fs';
-import swaggerUi from 'swagger-ui-express';
-import yaml from 'yamljs';
-import Logger from './logger.js';
+import express from "express";
+import cookieParser from "cookie-parser";
+import { initializeDatabase, shutdownDatabase } from "./config/database.js";
+import snippetRoutes from "./routes/snippetRoutes.js";
+import authRoutes from "./routes/authRoutes.js";
+import shareRoutes from "./routes/shareRoutes.js";
+import publicRoutes from "./routes/publicRoutes.js";
+import oidcRoutes from "./routes/oidcRoutes.js";
+import embedRoutes from "./routes/embedRoutes.js";
+import apiKeyRoutes from "./routes/apiKeyRoutes.js";
+import apiSnippetRoutes from "./routes/apiSnippetRoutes.js";
+import { authenticateToken } from "./middleware/auth.js";
+import { authenticateApiKey } from "./middleware/apiKeyAuth.js";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+import fs from "fs";
+import swaggerUi from "swagger-ui-express";
+import yaml from "yamljs";
+import Logger from "./logger.js";
 
 const app = express();
 const PORT = 5000;
 
-app.use(express.json());
+app.use(express.json({ limit: "2mb" }));
 app.use(cookieParser());
-app.set('trust proxy', true);
+app.set("trust proxy", true);
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-const basePath = process.env.BASE_PATH || '';
-const buildPath = join(__dirname, '../../client/build');
-const assetsPath = join(buildPath, 'assets');
+const basePath = process.env.BASE_PATH || "";
+const buildPath = join(__dirname, "../../client/build");
+const assetsPath = join(buildPath, "assets");
 
-const swaggerPath = join(__dirname, '../docs/swagger.yaml');
+const swaggerPath = join(__dirname, "../docs/swagger.yaml");
 const swaggerDocument = yaml.load(swaggerPath);
-app.use(`${basePath}/api-docs`, swaggerUi.serve, swaggerUi.setup(swaggerDocument));
+app.use(
+  `${basePath}/api-docs`,
+  swaggerUi.serve,
+  swaggerUi.setup(swaggerDocument)
+);
 
 app.use(`${basePath}/api/auth`, authRoutes);
 app.use(`${basePath}/api/auth/oidc`, oidcRoutes);
 app.use(`${basePath}/api/keys`, authenticateToken, apiKeyRoutes);
-app.use(`${basePath}/api/snippets`, authenticateApiKey, authenticateToken, snippetRoutes);
+app.use(
+  `${basePath}/api/snippets`,
+  authenticateApiKey,
+  authenticateToken,
+  snippetRoutes
+);
 app.use(`${basePath}/api/share`, shareRoutes);
 app.use(`${basePath}/api/public/snippets`, publicRoutes);
 app.use(`${basePath}/api/embed`, embedRoutes);
 app.use(`${basePath}/api/v1/snippets`, apiSnippetRoutes);
 
-app.use(`${basePath}/manifest.json`, express.static(join(buildPath, 'manifest.json')));
+app.use(
+  `${basePath}/manifest.json`,
+  express.static(join(buildPath, "manifest.json"))
+);
 
-app.get('/', (req, res, next) => {
+app.get("/", (req, res, next) => {
   if (basePath) {
     return res.redirect(basePath);
   }
@@ -55,7 +67,10 @@ app.get('/', (req, res, next) => {
 });
 
 app.use(`${basePath}/assets`, express.static(assetsPath));
-app.use(`${basePath}/monacoeditorwork`, express.static(join(buildPath, 'monacoeditorwork')));
+app.use(
+  `${basePath}/monacoeditorwork`,
+  express.static(join(buildPath, "monacoeditorwork"))
+);
 app.use(basePath, express.static(buildPath, { index: false }));
 
 /*
@@ -75,34 +90,26 @@ app.get(`${basePath}/*`, (req, res, next) => {
 
   // Don't cache, if the base path changes the previous index.html file is still used which will have incorrect paths
   res.set({
-    'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
-    'Pragma': 'no-cache',
-    'Expires': '0',
+    "Cache-Control": "no-store, no-cache, must-revalidate, proxy-revalidate",
+    Pragma: "no-cache",
+    Expires: "0",
   });
 
-  fs.readFile(join(buildPath, 'index.html'), 'utf8', (err, data) => {
+  fs.readFile(join(buildPath, "index.html"), "utf8", (err, data) => {
     if (err) {
-      Logger.error('Failed to read index.html:', err)
-      return res.status(500).send('Error loading index.html');
+      Logger.error("Failed to read index.html:", err);
+      return res.status(500).send("Error loading index.html");
     }
 
-    const modifiedHtml = data.replace(
-      /(src|href)="\/assets\//g,
-      `$1="${basePath}/assets/`
-    ).replace(
-      /\/monacoeditorwork\//g,
-      `${basePath}/monacoeditorwork/`
-    ).replace(
-      /(href)="\/manifest\.json"/g,
-      `$1="${basePath}/manifest.json"`
-    ).replace(
-      /(href)="\/favicon\.ico"/g,
-      `$1="${basePath}/favicon.ico"`
-    );
+    const modifiedHtml = data
+      .replace(/(src|href)="\/assets\//g, `$1="${basePath}/assets/`)
+      .replace(/\/monacoeditorwork\//g, `${basePath}/monacoeditorwork/`)
+      .replace(/(href)="\/manifest\.json"/g, `$1="${basePath}/manifest.json"`)
+      .replace(/(href)="\/favicon\.ico"/g, `$1="${basePath}/favicon.ico"`);
 
     const scriptInjection = `<script>window.__BASE_PATH__ = "${basePath}";</script>`;
     const injectedHtml = modifiedHtml.replace(
-      '</head>',
+      "</head>",
       `${scriptInjection}</head>`
     );
 
@@ -111,7 +118,7 @@ app.get(`${basePath}/*`, (req, res, next) => {
 });
 
 function handleShutdown() {
-  Logger.info('Received shutdown signal, starting graceful shutdown...');
+  Logger.info("Received shutdown signal, starting graceful shutdown...");
 
   shutdownDatabase();
 
@@ -129,5 +136,5 @@ function handleShutdown() {
   });
 })();
 
-process.on('SIGTERM', handleShutdown);
-process.on('SIGINT', handleShutdown);
+process.on("SIGTERM", handleShutdown);
+process.on("SIGINT", handleShutdown);


### PR DESCRIPTION
Increased the express.json body limit from the default (~100 KB) to 2 MB to fix an issue where saving larger code snippets (up to 1 MB) failed with a PayloadTooLargeError. This change ensures snippets can be saved reliably without exceeding the intended maximum size.

Closes #209