### PR TITLE
feat: enable sharing public snippets via category and language URL (#275)

### DIFF
--- a/client/src/components/search/SearchAndFilter.tsx
+++ b/client/src/components/search/SearchAndFilter.tsx
@@ -25,7 +25,7 @@ export interface SearchAndFilterProps {
   searchTerm: string;
   setSearchTerm: (term: string) => void;
   selectedLanguage: string;
-  setSelectedLanguage: (language: string) => void;
+  onLanguageChange: (language: string) => void;
   languages: string[];
   sortOrder: SortOrder;
   setSortOrder: (order: SortOrder) => void;
@@ -46,7 +46,7 @@ export const SearchAndFilter: React.FC<SearchAndFilterProps> = ({
   searchTerm,
   setSearchTerm,
   selectedLanguage,
-  setSelectedLanguage,
+  onLanguageChange,
   languages,
   sortOrder,
   setSortOrder,
@@ -77,7 +77,7 @@ export const SearchAndFilter: React.FC<SearchAndFilterProps> = ({
         <select
           className="px-4 py-2 pr-10 rounded-lg appearance-none bg-light-surface dark:bg-dark-surface text-light-text dark:text-dark-text focus:outline-none focus:ring-2 focus:ring-light-primary dark:focus:ring-dark-primary"
           value={selectedLanguage}
-          onChange={(e) => setSelectedLanguage(e.target.value)}
+          onChange={(e) => onLanguageChange(e.target.value)}
         >
           <option value="">All Languages</option>
           {languages.map((lang) => (


### PR DESCRIPTION
# Share snippets via category and language URL parameters

## Description
This PR enables sharing of snippets filtered by **category** and **language** via URL.

## Key Changes
- URL query parameters (`categories` and `language`) are updated dynamically when filters are applied or removed.  
- Removing a category preserves other active filters in the URL.  
- Selected categories and language are read from URL on page load to initialize filters.  
- `handleCategoryClick` and `handleLanguageChange` refactored to maintain proper query state.  
- **Note:** Shared links will only display **public snippets**. Private snippets are not accessible via shared URLs.

## Benefit
Users can now share links that directly display filtered snippets, improving usability and collaboration.

## Demo
A short demo video is attached to showcase the feature:
[Watch Video](https://drive.google.com/file/d/1k-YTrV52qIKaPScNcl1ZKpVdI6273Zvb/view?usp=sharing)

## Closes
- #275
- #99