### PR TITLE
feat: add support for github style admonitions in markdown (#263)

### DIFF
--- a/client/src/components/editor/FullCodeBlock.tsx
+++ b/client/src/components/editor/FullCodeBlock.tsx
@@ -1,11 +1,19 @@
-import React, { useEffect, useRef, useState } from 'react';
-import ReactMarkdown from 'react-markdown';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { vscDarkPlus, oneLight } from 'react-syntax-highlighter/dist/cjs/styles/prism';
-import { getLanguageLabel, getMonacoLanguage } from '../../utils/language/languageUtils';
-import CopyButton from '../common/buttons/CopyButton';
-import { useTheme } from '../../contexts/ThemeContext';
-import RawButton from '../common/buttons/RawButton';
+import React, { useEffect, useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import {
+  vscDarkPlus,
+  oneLight,
+} from "react-syntax-highlighter/dist/cjs/styles/prism";
+import {
+  getLanguageLabel,
+  getMonacoLanguage,
+} from "../../utils/language/languageUtils";
+import CopyButton from "../common/buttons/CopyButton";
+import { useTheme } from "../../contexts/ThemeContext";
+import RawButton from "../common/buttons/RawButton";
+import Admonition from "../utils/Admonition";
+import { flattenToText } from "../../utils/markdownUtils";
 
 export interface FullCodeBlockProps {
   code: string;
@@ -16,36 +24,38 @@ export interface FullCodeBlockProps {
   fragmentId?: string;
 }
 
-export const FullCodeBlock: React.FC<FullCodeBlockProps> = ({ 
-  code, 
-  language = 'plaintext',
+export const FullCodeBlock: React.FC<FullCodeBlockProps> = ({
+  code,
+  language = "plaintext",
   showLineNumbers = true,
   isPublicView,
   snippetId,
-  fragmentId
+  fragmentId,
 }) => {
   const { theme } = useTheme();
-  const [effectiveTheme, setEffectiveTheme] = useState<'light' | 'dark'>(
-    theme === 'system' 
-      ? window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  const [effectiveTheme, setEffectiveTheme] = useState<"light" | "dark">(
+    theme === "system"
+      ? window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? "dark"
+        : "light"
       : theme
   );
-  
+
   useEffect(() => {
-    if (theme === 'system') {
-      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    if (theme === "system") {
+      const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
       const handleChange = () => {
-        setEffectiveTheme(mediaQuery.matches ? 'dark' : 'light');
+        setEffectiveTheme(mediaQuery.matches ? "dark" : "light");
       };
-      mediaQuery.addEventListener('change', handleChange);
-      return () => mediaQuery.removeEventListener('change', handleChange);
+      mediaQuery.addEventListener("change", handleChange);
+      return () => mediaQuery.removeEventListener("change", handleChange);
     } else {
       setEffectiveTheme(theme);
     }
   }, [theme]);
 
-  const isDark = effectiveTheme === 'dark';
-  const isMarkdown = getLanguageLabel(language) === 'markdown';
+  const isDark = effectiveTheme === "dark";
+  const isMarkdown = getLanguageLabel(language) === "markdown";
   const [highlighterHeight, setHighlighterHeight] = useState<string>("100px");
   const containerRef = useRef<HTMLDivElement>(null);
   const LINE_HEIGHT = 19;
@@ -61,31 +71,31 @@ export const FullCodeBlock: React.FC<FullCodeBlockProps> = ({
 
   const updateHighlighterHeight = () => {
     if (!containerRef.current) return;
-    
-    const lineCount = code.split('\n').length;
-    const contentHeight = (lineCount * LINE_HEIGHT) + 35;
+
+    const lineCount = code.split("\n").length;
+    const contentHeight = lineCount * LINE_HEIGHT + 35;
     const newHeight = Math.min(500, Math.max(100, contentHeight));
     setHighlighterHeight(`${newHeight}px`);
   };
 
   const baseTheme = isDark ? vscDarkPlus : oneLight;
-  const backgroundColor = isDark ? '#1E1E1E' : '#ffffff';
+  const backgroundColor = isDark ? "#1E1E1E" : "#ffffff";
   const customStyle = {
     ...baseTheme,
     'pre[class*="language-"]': {
       ...baseTheme['pre[class*="language-"]'],
       margin: 0,
-      fontSize: '13px',
+      fontSize: "13px",
       background: backgroundColor,
-      padding: '1rem',
+      padding: "1rem",
     },
     'code[class*="language-"]': {
       ...baseTheme['code[class*="language-"]'],
-      fontSize: '13px',
+      fontSize: "13px",
       background: backgroundColor,
-      display: 'block',
+      display: "block",
       textIndent: 0,
-    }
+    },
   };
 
   return (
@@ -100,43 +110,73 @@ export const FullCodeBlock: React.FC<FullCodeBlockProps> = ({
             position: relative;
           }
           :root {
-            --text-color: ${isDark ? '#ffffff' : '#000000'};
+            --text-color: ${isDark ? "#ffffff" : "#000000"};
           }
         `}
       </style>
       <div className="relative">
         {isMarkdown ? (
-          <div className="markdown-content markdown-content-full rounded-lg" style={{ backgroundColor }}>
-            <ReactMarkdown className={`markdown prose ${isDark ? 'prose-invert' : ''} max-w-none`}>
+          <div
+            className="rounded-lg markdown-content markdown-content-full"
+            style={{ backgroundColor }}
+          >
+            <ReactMarkdown
+              className={`markdown prose ${
+                isDark ? "prose-invert" : ""
+              } max-w-none`}
+              components={{
+                blockquote: ({ children }) => {
+                  const text = flattenToText(children).trim();
+                  const match = text.match(
+                    /^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*([\s\S]*)$/
+                  );
+                  if (match) {
+                    return (
+                      <Admonition type={match[1]}>{match[2].trim()}</Admonition>
+                    );
+                  }
+                  return <blockquote>{children}</blockquote>;
+                },
+                p: ({ children }) => {
+                  const text = flattenToText(children).trim();
+                  const match = text.match(
+                    /^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*([\s\S]*)$/
+                  );
+                  if (match) {
+                    return (
+                      <Admonition type={match[1]}>{match[2].trim()}</Admonition>
+                    );
+                  }
+                  return <p>{children}</p>;
+                },
+              }}
+            >
               {code}
             </ReactMarkdown>
           </div>
         ) : (
-          <div 
-            ref={containerRef}
-            style={{ maxHeight: '500px' }}
-          >
+          <div ref={containerRef} style={{ maxHeight: "500px" }}>
             <SyntaxHighlighter
               language={getMonacoLanguage(language)}
               style={customStyle}
               showLineNumbers={showLineNumbers}
               wrapLines={true}
               lineProps={{
-                style: { 
-                  whiteSpace: 'pre',
-                  wordBreak: 'break-all',
-                  paddingLeft: 0
-                }
+                style: {
+                  whiteSpace: "pre",
+                  wordBreak: "break-all",
+                  paddingLeft: 0,
+                },
               }}
               customStyle={{
                 height: highlighterHeight,
-                minHeight: '100px',
+                minHeight: "100px",
                 marginBottom: 0,
                 marginTop: 0,
                 textIndent: 0,
                 paddingLeft: showLineNumbers ? 10 : 20,
-                borderRadius: '0.5rem',
-                background: backgroundColor
+                borderRadius: "0.5rem",
+                background: backgroundColor,
               }}
             >
               {code}
@@ -145,14 +185,16 @@ export const FullCodeBlock: React.FC<FullCodeBlockProps> = ({
         )}
 
         <CopyButton text={code} />
-        {isPublicView !== undefined && snippetId !== undefined && fragmentId !== undefined && (
-          <RawButton
-            isPublicView={isPublicView}
-            snippetId={snippetId}
-            fragmentId={fragmentId}
-          />
-        )}
+        {isPublicView !== undefined &&
+          snippetId !== undefined &&
+          fragmentId !== undefined && (
+            <RawButton
+              isPublicView={isPublicView}
+              snippetId={snippetId}
+              fragmentId={fragmentId}
+            />
+          )}
       </div>
     </div>
   );
-}
+};

--- a/client/src/components/snippets/embed/EmbedCodeView.tsx
+++ b/client/src/components/snippets/embed/EmbedCodeView.tsx
@@ -1,46 +1,58 @@
-import React, { useEffect, useRef, useState } from 'react';
-import ReactMarkdown from 'react-markdown';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { vscDarkPlus, oneLight } from 'react-syntax-highlighter/dist/cjs/styles/prism';
-import { getLanguageLabel, getMonacoLanguage } from '../../../utils/language/languageUtils';
-import EmbedCopyButton from './EmbedCopyButton';
+import React, { useEffect, useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import {
+  vscDarkPlus,
+  oneLight,
+} from "react-syntax-highlighter/dist/cjs/styles/prism";
+import {
+  getLanguageLabel,
+  getMonacoLanguage,
+} from "../../../utils/language/languageUtils";
+import EmbedCopyButton from "./EmbedCopyButton";
+import Admonition from "../../utils/Admonition";
+import { flattenToText } from "../../../utils/markdownUtils";
 
 export interface EmbedCodeBlockProps {
   code: string;
   language?: string;
   showLineNumbers?: boolean;
-  theme?: 'light' | 'dark' | 'blue' | 'system';
+  theme?: "light" | "dark" | "blue" | "system";
 }
 
-export const EmbedCodeView: React.FC<EmbedCodeBlockProps> = ({ 
-  code, 
-  language = 'plaintext',
+export const EmbedCodeView: React.FC<EmbedCodeBlockProps> = ({
+  code,
+  language = "plaintext",
   showLineNumbers = true,
-  theme = 'system'
+  theme = "system",
 }) => {
-  const [effectiveTheme, setEffectiveTheme] = useState<'light' | 'dark' | 'blue'>(() => {
-    if (theme === 'system') {
-      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  const [effectiveTheme, setEffectiveTheme] = useState<
+    "light" | "dark" | "blue"
+  >(() => {
+    if (theme === "system") {
+      return window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? "dark"
+        : "light";
     }
     return theme;
   });
-  
+
   useEffect(() => {
-    if (theme !== 'system') {
+    if (theme !== "system") {
       setEffectiveTheme(theme);
       return;
     }
 
-    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
     const handleChange = () => {
-      setEffectiveTheme(mediaQuery.matches ? 'dark' : 'light');
+      setEffectiveTheme(mediaQuery.matches ? "dark" : "light");
     };
-    mediaQuery.addEventListener('change', handleChange);
-    return () => mediaQuery.removeEventListener('change', handleChange);
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
   }, [theme]);
 
-  const isDark = effectiveTheme === 'dark' || effectiveTheme === 'blue';
-  const isMarkdown = getLanguageLabel(language) === 'markdown';
+  const isDark = effectiveTheme === "dark" || effectiveTheme === "blue";
+  const isMarkdown = getLanguageLabel(language) === "markdown";
   const [highlighterHeight, setHighlighterHeight] = useState<string>("100px");
   const containerRef = useRef<HTMLDivElement>(null);
   const LINE_HEIGHT = 19;
@@ -56,9 +68,9 @@ export const EmbedCodeView: React.FC<EmbedCodeBlockProps> = ({
 
   const updateHighlighterHeight = () => {
     if (!containerRef.current) return;
-    
-    const lineCount = code.split('\n').length;
-    const contentHeight = (lineCount * LINE_HEIGHT) + 35;
+
+    const lineCount = code.split("\n").length;
+    const contentHeight = lineCount * LINE_HEIGHT + 35;
     const newHeight = Math.min(500, Math.max(100, contentHeight));
     setHighlighterHeight(`${newHeight}px`);
   };
@@ -66,11 +78,11 @@ export const EmbedCodeView: React.FC<EmbedCodeBlockProps> = ({
   const baseTheme = isDark ? vscDarkPlus : oneLight;
   const getBackgroundColor = () => {
     switch (effectiveTheme) {
-      case 'blue':
-      case 'dark':
-        return '#1E1E1E';
-      case 'light':
-        return '#ffffff';
+      case "blue":
+      case "dark":
+        return "#1E1E1E";
+      case "light":
+        return "#ffffff";
     }
   };
 
@@ -80,17 +92,17 @@ export const EmbedCodeView: React.FC<EmbedCodeBlockProps> = ({
     'pre[class*="language-"]': {
       ...baseTheme['pre[class*="language-"]'],
       margin: 0,
-      fontSize: '13px',
+      fontSize: "13px",
       background: backgroundColor,
-      padding: '1rem',
+      padding: "1rem",
     },
     'code[class*="language-"]': {
       ...baseTheme['code[class*="language-"]'],
-      fontSize: '13px',
+      fontSize: "13px",
       background: backgroundColor,
-      display: 'block',
+      display: "block",
       textIndent: 0,
-    }
+    },
   };
 
   return (
@@ -106,8 +118,8 @@ export const EmbedCodeView: React.FC<EmbedCodeBlockProps> = ({
           }
           .markdown-content-full pre,
           .markdown-content-full code {
-            background-color: ${isDark ? '#2d2d2d' : '#ebebeb'} !important;
-            color: ${isDark ? '#e5e7eb' : '#1f2937'} !important;
+            background-color: ${isDark ? "#2d2d2d" : "#ebebeb"} !important;
+            color: ${isDark ? "#e5e7eb" : "#1f2937"} !important;
           }
           .markdown-content-full pre code {
             background-color: transparent !important;
@@ -116,43 +128,73 @@ export const EmbedCodeView: React.FC<EmbedCodeBlockProps> = ({
             box-shadow: none;
           }
           :root {
-            --text-color: ${isDark ? '#ffffff' : '#000000'};
+            --text-color: ${isDark ? "#ffffff" : "#000000"};
           }
         `}
       </style>
       <div className="relative">
         {isMarkdown ? (
-          <div className="markdown-content markdown-content-full rounded-lg" style={{ backgroundColor }}>
-            <ReactMarkdown className={`markdown prose ${isDark ? 'prose-invert' : ''} max-w-none`}>
+          <div
+            className="rounded-lg markdown-content markdown-content-full"
+            style={{ backgroundColor }}
+          >
+            <ReactMarkdown
+              className={`markdown prose ${
+                isDark ? "prose-invert" : ""
+              } max-w-none`}
+              components={{
+                blockquote: ({ children }) => {
+                  const text = flattenToText(children).trim();
+                  const match = text.match(
+                    /^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*([\s\S]*)$/
+                  );
+                  if (match) {
+                    return (
+                      <Admonition type={match[1]}>{match[2].trim()}</Admonition>
+                    );
+                  }
+                  return <blockquote>{children}</blockquote>;
+                },
+                p: ({ children }) => {
+                  const text = flattenToText(children).trim();
+                  const match = text.match(
+                    /^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*([\s\S]*)$/
+                  );
+                  if (match) {
+                    return (
+                      <Admonition type={match[1]}>{match[2].trim()}</Admonition>
+                    );
+                  }
+                  return <p>{children}</p>;
+                },
+              }}
+            >
               {code}
             </ReactMarkdown>
           </div>
         ) : (
-          <div 
-            ref={containerRef}
-            style={{ maxHeight: '500px' }}
-          >
+          <div ref={containerRef} style={{ maxHeight: "500px" }}>
             <SyntaxHighlighter
               language={getMonacoLanguage(language)}
               style={customStyle}
               showLineNumbers={showLineNumbers}
               wrapLines={true}
               lineProps={{
-                style: { 
-                  whiteSpace: 'pre',
-                  wordBreak: 'break-all',
-                  paddingLeft: 0
-                }
+                style: {
+                  whiteSpace: "pre",
+                  wordBreak: "break-all",
+                  paddingLeft: 0,
+                },
               }}
               customStyle={{
                 height: highlighterHeight,
-                minHeight: '100px',
+                minHeight: "100px",
                 marginBottom: 0,
                 marginTop: 0,
                 textIndent: 0,
                 paddingLeft: showLineNumbers ? 10 : 20,
-                borderRadius: '0.5rem',
-                background: backgroundColor
+                borderRadius: "0.5rem",
+                background: backgroundColor,
               }}
             >
               {code}

--- a/client/src/components/utils/Admonition.tsx
+++ b/client/src/components/utils/Admonition.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import {
+  Info,
+  Lightbulb,
+  MessageSquareWarning,
+  AlertTriangle,
+  AlertOctagon,
+} from "lucide-react";
+
+type AdmonitionType = "NOTE" | "TIP" | "IMPORTANT" | "WARNING" | "CAUTION";
+
+const CONFIG: Record<
+  AdmonitionType,
+  {
+    title: string;
+    container: string;
+    bar: string;
+    titleColor: string;
+    iconColor: string;
+    Icon: React.ComponentType<{ className?: string }>;
+  }
+> = {
+  NOTE: {
+    title: "Note",
+    container: "bg-blue-500/10 dark:bg-blue-500/10",
+    bar: "bg-blue-500",
+    titleColor: "text-blue-600 dark:text-blue-400",
+    iconColor: "text-blue-500",
+    Icon: Info,
+  },
+  TIP: {
+    title: "Tip",
+    container: "bg-green-500/10 dark:bg-green-500/10",
+    bar: "bg-green-500",
+    titleColor: "text-green-600 dark:text-green-400",
+    iconColor: "text-green-500",
+    Icon: Lightbulb,
+  },
+  IMPORTANT: {
+    title: "Important",
+    container: "bg-purple-500/10 dark:bg-purple-500/10",
+    bar: "bg-purple-500",
+    titleColor: "text-purple-600 dark:text-purple-400",
+    iconColor: "text-purple-500",
+    Icon: MessageSquareWarning,
+  },
+  WARNING: {
+    title: "Warning",
+    container: "bg-amber-500/10 dark:bg-amber-500/10",
+    bar: "bg-amber-500",
+    titleColor: "text-amber-600 dark:text-amber-400",
+    iconColor: "text-amber-500",
+    Icon: AlertTriangle,
+  },
+  CAUTION: {
+    title: "Caution",
+    container: "bg-red-500/10 dark:bg-red-500/10",
+    bar: "bg-red-500",
+    titleColor: "text-red-600 dark:text-red-400",
+    iconColor: "text-red-500",
+    Icon: AlertOctagon,
+  },
+};
+
+const Admonition: React.FC<{ type: string; children: React.ReactNode }> = ({
+  type,
+  children,
+}) => {
+  const key = (type?.toUpperCase() as AdmonitionType) || "NOTE";
+  const cfg = CONFIG[key] || CONFIG.NOTE;
+
+  return (
+    <div className={`not-prose my-3 relative overflow-hidden ${cfg.container}`}>
+      <div className="flex items-stretch">
+        <span
+          aria-hidden
+          className={`block w-1 ${cfg.bar}`}
+          style={{ minHeight: "100%", height: "auto" }}
+        />
+        <div className="flex items-start flex-1 gap-2 p-2">
+          <cfg.Icon className={`mt-0.5 h-5 w-5 ${cfg.iconColor}`} />
+          <div className="flex-1">
+            <div className={`font-semibold ${cfg.titleColor}`}>{cfg.title}</div>
+            {children && (
+              <div className="mt-1 text-sm leading-relaxed">{children}</div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Admonition;

--- a/client/src/utils/markdownUtils.ts
+++ b/client/src/utils/markdownUtils.ts
@@ -1,0 +1,19 @@
+import { ReactNode } from "react";
+
+export const flattenToText = (node: ReactNode): string => {
+  if (!node) return "";
+
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node);
+  }
+
+  if (Array.isArray(node)) {
+    return node.reduce((text, child) => text + flattenToText(child), "");
+  }
+
+  if (typeof node === "object" && "props" in node) {
+    return flattenToText(node.props?.children);
+  }
+
+  return "";
+};


### PR DESCRIPTION
## Summary
Adds support for GitHub-style admonitions in ByteStash markdown format (`NOTE`, `TIP`, `IMPORTANT`, `WARNING`, `CAUTION`) to highlight key information and warnings.

#### [Demo](https://drive.google.com/file/d/1wEbwxKG4mkPL_yV7naL3DUyaeNCIVeOU/view?usp=sharing)

Closes #263