### PR TITLE
feat: implemented clear all snippets permanently feature in recycle bin (#283)

### DIFF
--- a/client/src/components/snippets/view/recycle/RecycleSnippetStorage.tsx
+++ b/client/src/components/snippets/view/recycle/RecycleSnippetStorage.tsx
@@ -1,21 +1,28 @@
-import React, { useState, useEffect } from 'react';
-import { useSettings } from '../../../../hooks/useSettings';
-import { useToast } from '../../../../hooks/useToast';
-import { useAuth } from '../../../../hooks/useAuth';
-import { initializeMonaco } from '../../../../utils/language/languageUtils';
-import SettingsModal from '../../../settings/SettingsModal';
-import BaseSnippetStorage from '../common/BaseSnippetStorage';
-import { getRecycleSnippets } from '../../../../utils/api/snippets';
-import { useSnippets } from '../../../../hooks/useSnippets';
-import { Snippet } from '../../../../types/snippets';
-import { UserDropdown } from '../../../auth/UserDropdown';
+import React, { useState, useEffect } from "react";
+import { useSettings } from "../../../../hooks/useSettings";
+import { useToast } from "../../../../hooks/useToast";
+import { useAuth } from "../../../../hooks/useAuth";
+import { initializeMonaco } from "../../../../utils/language/languageUtils";
+import SettingsModal from "../../../settings/SettingsModal";
+import BaseSnippetStorage from "../common/BaseSnippetStorage";
+import { getRecycleSnippets } from "../../../../utils/api/snippets";
+import { useSnippets } from "../../../../hooks/useSnippets";
+import { Snippet } from "../../../../types/snippets";
+import { UserDropdown } from "../../../auth/UserDropdown";
 
 const RecycleSnippetStorage: React.FC = () => {
-  const { 
-    viewMode, setViewMode, compactView, showCodePreview, 
-    previewLines, includeCodeInSearch, updateSettings,
-    showCategories, expandCategories, showLineNumbers,
-    theme
+  const {
+    viewMode,
+    setViewMode,
+    compactView,
+    showCodePreview,
+    previewLines,
+    includeCodeInSearch,
+    updateSettings,
+    showCategories,
+    expandCategories,
+    showLineNumbers,
+    theme,
   } = useSettings();
 
   const { isAuthenticated } = useAuth();
@@ -23,7 +30,8 @@ const RecycleSnippetStorage: React.FC = () => {
   const [snippets, setSnippets] = useState<Snippet[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
-  const { permanentDeleteSnippet, restoreSnippet } = useSnippets();
+  const { permanentDeleteSnippet, restoreSnippet, permanentDeleteAllSnippets } =
+    useSnippets();
 
   useEffect(() => {
     initializeMonaco();
@@ -35,8 +43,8 @@ const RecycleSnippetStorage: React.FC = () => {
       const fetchedSnippets = await getRecycleSnippets();
       setSnippets(fetchedSnippets);
     } catch (error) {
-      console.error('Failed to load recycled snippets:', error);
-      addToast('Failed to load recycled snippets', 'error');
+      console.error("Failed to load recycled snippets:", error);
+      addToast("Failed to load recycled snippets", "error");
     } finally {
       setIsLoading(false);
     }
@@ -58,6 +66,10 @@ const RecycleSnippetStorage: React.FC = () => {
           await permanentDeleteSnippet(id);
           loadSnippets(); // refresh after delete
         }}
+        onPermanentDeleteAll={async () => {
+          await permanentDeleteAllSnippets(snippets);
+          loadSnippets(); // refresh after delete all
+        }}
         onRestore={restoreSnippet}
         expandCategories={expandCategories}
         showLineNumbers={showLineNumbers}
@@ -72,15 +84,15 @@ const RecycleSnippetStorage: React.FC = () => {
       <SettingsModal
         isOpen={isSettingsModalOpen}
         onClose={() => setIsSettingsModalOpen(false)}
-        settings={{ 
-          compactView, 
-          showCodePreview, 
-          previewLines, 
-          includeCodeInSearch, 
-          showCategories, 
-          expandCategories, 
+        settings={{
+          compactView,
+          showCodePreview,
+          previewLines,
+          includeCodeInSearch,
+          showCategories,
+          expandCategories,
           showLineNumbers,
-          theme
+          theme,
         }}
         onSettingsChange={updateSettings}
         snippets={[]}

--- a/client/src/hooks/useSnippets.ts
+++ b/client/src/hooks/useSnippets.ts
@@ -232,6 +232,23 @@ export const useSnippets = () => {
     loadSnippets(true);
   }, [loadSnippets]);
 
+  const permanentDeleteAllSnippets = useCallback(
+    async (recycleBinSnippets: Snippet[]) => {
+      try {
+        await Promise.all(recycleBinSnippets.map((s) => deleteSnippet(s.id)));
+        setSnippets((prev) =>
+          prev.filter((s) => !recycleBinSnippets.some((r) => r.id === s.id))
+        );
+        addToast("All snippets in the recycle bin are cleared.", "success");
+      } catch (error: any) {
+        console.error("Failed to clear all recycle bin snippets:", error);
+        handleAuthError(error);
+        addToast("Failed to clear recycle bin. Please try again.", "error");
+      }
+    },
+    [addToast, handleAuthError]
+  );
+
   useEffect(() => {
     mountedRef.current = true;
 
@@ -252,6 +269,7 @@ export const useSnippets = () => {
       updateSnippet,
       removeSnippet,
       permanentDeleteSnippet,
+      permanentDeleteAllSnippets,
       restoreSnippet,
       pinSnippet,
       favoriteSnippet,


### PR DESCRIPTION
## Summary

Implemented a **"Clear all"** button in the Recycle Bin to permanently delete all snippets at once with a confirmation prompt, updating the UI and backend state accordingly.

### Demo
[Watch Video](https://drive.google.com/file/d/1ozl_8y2e2n83qrbsbwNBQ5_hwy6SM2eQ/view?usp=sharing)

### Issue
Closes #283