### PR TITLE
feat: add global '/' key shortcut to focus search input

### DIFF
--- a/client/src/components/common/dropdowns/BaseDropdown.tsx
+++ b/client/src/components/common/dropdowns/BaseDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef, useEffect, forwardRef, useImperativeHandle } from "react";
 import { ChevronDown } from "lucide-react";
 
 interface Section {
@@ -19,7 +19,15 @@ export interface BaseDropdownProps {
   showChevron?: boolean;
 }
 
-const BaseDropdown: React.FC<BaseDropdownProps> = ({
+/**
+ * Ref interface for BaseDropdown component
+ */
+export interface BaseDropdownRef {
+  /** Focus the dropdown input */
+  focus: () => void;
+}
+
+const BaseDropdown = forwardRef<BaseDropdownRef, BaseDropdownProps>(({
   value,
   onChange,
   onSelect,
@@ -30,7 +38,7 @@ const BaseDropdown: React.FC<BaseDropdownProps> = ({
   disabled = false,
   maxLength,
   showChevron = true,
-}) => {
+}, ref) => {
   const [isOpen, setIsOpen] = useState(false);
   const [highlightedIndex, setHighlightedIndex] = useState<number>(-1);
   const [internalValue, setInternalValue] = useState(value);
@@ -38,6 +46,14 @@ const BaseDropdown: React.FC<BaseDropdownProps> = ({
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
   const lastInteractionWasMouse = useRef(false);
+
+  useImperativeHandle(ref, () => ({
+    focus: () => {
+      if (inputRef.current) {
+        inputRef.current.focus();
+      }
+    },
+  }));
 
   useEffect(() => {
     setInternalValue(value);
@@ -237,6 +253,8 @@ const BaseDropdown: React.FC<BaseDropdownProps> = ({
       )}
     </div>
   );
-};
+});
+
+BaseDropdown.displayName = 'BaseDropdown';
 
 export default BaseDropdown;

--- a/client/src/components/search/SearchBar.tsx
+++ b/client/src/components/search/SearchBar.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Search, X } from 'lucide-react';
-import BaseDropdown from '../common/dropdowns/BaseDropdown';
+import BaseDropdown, { BaseDropdownRef } from '../common/dropdowns/BaseDropdown';
 import { IconButton } from '../common/buttons/IconButton';
+import { useKeyboardShortcut } from '../../hooks/useKeyboardShortcut';
 
 interface SearchBarProps {
   value: string;
@@ -22,6 +23,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({
 }) => {
   const [inputValue, setInputValue] = useState(value);
   const lastValueRef = useRef(value);
+  const inputRef = useRef<BaseDropdownRef>(null);
 
   useEffect(() => {
     if (value !== lastValueRef.current) {
@@ -29,6 +31,16 @@ export const SearchBar: React.FC<SearchBarProps> = ({
       lastValueRef.current = value;
     }
   }, [value]);
+
+  // Focus the search input when "/" key is pressed
+  useKeyboardShortcut({
+    key: '/',
+    callback: () => {
+      if (inputRef.current) {
+        inputRef.current.focus();
+      }
+    },
+  });
 
   const getSections = (searchTerm: string) => {
     if (!searchTerm.includes('#')) return [];
@@ -79,6 +91,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({
   return (
     <div className="relative flex-grow">
       <BaseDropdown
+        ref={inputRef}
         value={inputValue}
         onChange={(value) => {
           setInputValue(value);

--- a/client/src/hooks/useKeyboardShortcut.ts
+++ b/client/src/hooks/useKeyboardShortcut.ts
@@ -1,0 +1,73 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Options for the useKeyboardShortcut hook
+ */
+interface UseKeyboardShortcutOptions {
+  /** The keyboard key to listen for (e.g., '/', 'Escape', 'Enter') */
+  key: string;
+  /** Function to call when the key is pressed */
+  callback: () => void;
+  /** Whether the shortcut is enabled (default: true) */
+  enabled?: boolean;
+  /** Whether to prevent the default browser behavior (default: true) */
+  preventDefault?: boolean;
+}
+
+/**
+ * Custom hook for handling global keyboard shortcuts
+ * 
+ * @param options - Configuration options for the keyboard shortcut
+ * @returns void
+ * 
+ * @example
+ * ```tsx
+ * useKeyboardShortcut({
+ *   key: '/',
+ *   callback: () => focusSearchInput(),
+ *   enabled: true,
+ *   preventDefault: true
+ * });
+ * ```
+ */
+export const useKeyboardShortcut = ({
+  key,
+  callback,
+  enabled = true,
+  preventDefault = true,
+}: UseKeyboardShortcutOptions) => {
+  const callbackRef = useRef(callback);
+
+  // Keep callback ref up to date
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      // Check if the pressed key matches our target key
+      if (event.key === key) {
+        // Don't trigger if user is typing in an input, textarea, or contenteditable
+        const target = event.target as HTMLElement;
+        const isTyping = 
+          target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.contentEditable === 'true';
+
+        if (!isTyping) {
+          if (preventDefault) {
+            event.preventDefault();
+          }
+          callbackRef.current();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [key, enabled, preventDefault]);
+};
+
+export default useKeyboardShortcut;


### PR DESCRIPTION
- Add useKeyboardShortcut hook for handling global keyboard shortcuts
- Enhance BaseDropdown component with forwardRef support and focus method
- Integrate keyboard shortcut into SearchBar component
- Prevent shortcut activation when typing in form elements
- Follows GitHub/Laravel.com search UX patterns

Resolves #287