### PR TITLE
[bug] fixed bug with pinned snippets not appearing first

### DIFF
--- a/server/src/repositories/snippetRepository.js
+++ b/server/src/repositories/snippetRepository.js
@@ -561,8 +561,8 @@ class SnippetRepository {
         params.push(...filters.categories, filters.categories.length);
       }
 
-      // Apply sorting
-      sql += ` ORDER BY `;
+      // Apply sorting - pinned snippets always come first
+      sql += ` ORDER BY s.is_pinned DESC, `;
       switch (sort) {
         case 'oldest':
           sql += `s.updated_at ASC`;


### PR DESCRIPTION
In the recent pagination changes, pinned snippets were not considered. They should always appear first in the list regardless of the selected sorting order.