### PR TITLE
[feat] added ini, conf, and vimscript as languages

### DIFF
--- a/client/src/utils/language/languageUtils.ts
+++ b/client/src/utils/language/languageUtils.ts
@@ -342,9 +342,24 @@ const LANGUAGE_MAPPING: LanguageMapping = {
     label: "xml",
   },
   toml: {
-    aliases: ["ini", "conf", "config", "cargo.toml", "poetry.toml"],
+    aliases: ["cargo.toml", "poetry.toml"],
     monacoAlias: "ini",
     label: "toml",
+  },
+  ini: {
+    aliases: ["cfg", "properties", "config", "ini-file", "windows-ini"],
+    monacoAlias: "ini",
+    label: "ini",
+  },
+  conf: {
+    aliases: ["config-file", "configuration", "nginx", "apache", "httpd.conf"],
+    monacoAlias: "ini",
+    label: "conf",
+  },
+  vimscript: {
+    aliases: ["vim", "vimrc", ".vimrc", "viml", "nvim", "neovim"],
+    monacoAlias: "plaintext",
+    label: "vimscript",
   },
 
   // Cloud & Infrastructure


### PR DESCRIPTION
Adds a few new languages with syntax highlighting. Monaco editor doesn't currently support Vim highlighting, so it's been put as plaintext instead.