### PR TITLE
feat(i18n): add comprehensive Italian (it) localization

### DIFF
--- a/client/i18next.config.ts
+++ b/client/i18next.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     Locale.es,
     Locale.ja,
     Locale.zh,
+    Locale.it
   ],
   extract: {
     input: 'src/**/*.{js,jsx,ts,tsx}',

--- a/client/src/i18n/config.ts
+++ b/client/src/i18n/config.ts
@@ -10,6 +10,7 @@ const DATE_FNS_LOCALE_MAP: Record<string, string> = {
   es: 'es',
   ru: 'ru',
   zh: 'zhCN',
+  it: 'it'
 };
 
 async function setDateFnsDefaultOptions(language?: string) {

--- a/client/src/i18n/constants.ts
+++ b/client/src/i18n/constants.ts
@@ -6,6 +6,7 @@ export const LOCALE_ISO_CODES: Record<Locale, string> = {
   [Locale.es]: 'es-ES',
   [Locale.ja]: 'ja-JP',
   [Locale.zh]: 'zh-CN',
+  [Locale.it]: 'it-IT',
 };
 export const DEFAULT_LOCALE: Locale = Locale.en;
 export const DEFAULT_LOCALE_ISO_CODE = LOCALE_ISO_CODES[Locale.en];

--- a/client/src/i18n/locales/it/components/admin/common.json
+++ b/client/src/i18n/locales/it/components/admin/common.json
@@ -1,0 +1,12 @@
+{
+  "adminTable": {
+    "defaultEmptyMessage": "Nessun Risultato",
+    "defaultLoadingMessage": "Caricamento..."
+  },
+  "filterInput": {
+    "defaultPlaceholder": "Ricerca..."
+  },
+  "filterSelect": {
+    "defaultPlaceholder": "Seleziona..."
+  }
+}

--- a/client/src/i18n/locales/it/components/admin/modals.json
+++ b/client/src/i18n/locales/it/components/admin/modals.json
@@ -1,0 +1,8 @@
+{
+  "snippetViewModal": {
+    "error": {
+      "failedLoad": "Errore caricamento snippet"
+    },
+    "title": "Caricamento snippet..."
+  }
+}

--- a/client/src/i18n/locales/it/components/admin/selector.json
+++ b/client/src/i18n/locales/it/components/admin/selector.json
@@ -1,0 +1,7 @@
+{
+  "apiKeys": "Chiavi API",
+  "dashboard": "Dashboard",
+  "shares": "Condivisioni",
+  "snippets": "Snippet",
+  "users": "Utenti"
+}

--- a/client/src/i18n/locales/it/components/admin/tabs/apiKeys.json
+++ b/client/src/i18n/locales/it/components/admin/tabs/apiKeys.json
@@ -1,0 +1,33 @@
+{
+  "apiKeyDeletedSuccessfully": "Chiave API cancellata con successo",
+  "columns": {
+    "labels": {
+      "actions": "Azioni",
+      "created": "Creata",
+      "lastUsed": "Ultimo utilizzo",
+      "name": "Nome",
+      "owner": "Proprietario",
+      "status": "Stato"
+    }
+  },
+  "confirmationModal": {
+    "message": "Sei sicuro di voler cancellare questa chiave API? Il suo proprietario non sarà più in grado di accedere all'API. L'azione non può esser annullata.",
+    "title": "Cancella Chiave API"
+  },
+  "entityName_one": "Chiave API",
+  "entityName_other": "Chiavi API",
+  "error": {
+    "default": "Errore cancellazione chiave API"
+  },
+  "filters": {
+    "userId": "Filtra per ID Utente"
+  },
+  "status": {
+    "active": "Attivo",
+    "inactive": "Disattivo"
+  },
+  "table": {
+    "emptyMessage": "Nessuna chiave API trovata",
+    "loadingMessage": "Caricamento chiavi API..."
+  }
+}

--- a/client/src/i18n/locales/it/components/admin/tabs/dashboard.json
+++ b/client/src/i18n/locales/it/components/admin/tabs/dashboard.json
@@ -1,0 +1,31 @@
+{
+  "card": {
+    "apiKeys": {
+      "title": "Chiavi API"
+    },
+    "shares": {
+      "title": "Condivisioni"
+    },
+    "snippets": {
+      "apiKeys": {
+        "active": "Attivo"
+      },
+      "shares": {
+        "total": "Totale"
+      },
+      "title": "Snippets",
+      "viewType": {
+        "private": "Privato",
+        "public": "Pubblico"
+      }
+    },
+    "users": {
+      "authType": {
+        "internal": "Interno",
+        "oidc": "OIDC"
+      },
+      "title": "Utenti"
+    }
+  },
+  "loadingMessage": "Caricamento statistiche..."
+}

--- a/client/src/i18n/locales/it/components/admin/tabs/shares.json
+++ b/client/src/i18n/locales/it/components/admin/tabs/shares.json
@@ -1,0 +1,49 @@
+{
+  "action": {
+    "copyShareLink": "Copia link di condivisione",
+    "delete": "Cancella condivisione",
+    "viewSnippet": "Mostra snippet"
+  },
+  "columns": {
+    "labels": {
+      "actions": "Azioni",
+      "auth": "Autenticazione necessaria",
+      "created": "Creato",
+      "expires": "Scade",
+      "id": "ID Condivisione",
+      "owner": "Proprietario",
+      "title": "Titolo"
+    }
+  },
+  "confirmationModal": {
+    "message": "Sei sicuro di voler cancellare questo link di condivisione? Chiunque con il vecchio link non sarà più in grado di accedere a questo snippet. L'azione non può essere annullata.",
+    "title": "Cancella condivisione"
+  },
+  "entityName_one": "condivisione",
+  "entityName_other": "condivisioni",
+  "error": {
+    "delete": {
+      "default": "Errore cancellazione condivisione"
+    }
+  },
+  "filters": {
+    "authType": {
+      "all": "Tutti i tipi di Autenticazione",
+      "public": "Pubblico",
+      "requiresAuth": "Richiede Autenticazione"
+    },
+    "userId": "Filtra per ID Utente"
+  },
+  "success": {
+    "copied": {
+      "default": "Link di condivisione copiato negli appunti"
+    },
+    "delete": {
+      "default": "Link di condivisione cancellato con successo"
+    }
+  },
+  "table": {
+    "emptyMessage": "Nessun Link di condivisione trovato",
+    "loadingMessage": "Caricamento condivisioni..."
+  }
+}

--- a/client/src/i18n/locales/it/components/admin/tabs/snippets.json
+++ b/client/src/i18n/locales/it/components/admin/tabs/snippets.json
@@ -1,0 +1,57 @@
+{
+  "action": {
+    "delete": "Cancella snippet",
+    "makePrivate": "Rendi privato",
+    "makePublic": "Rendi pubblico",
+    "scanForOffensiveContent": "Scansione per Contenuti Offensivi",
+    "showAllSnippets": "Mostra tutti gli Snippet",
+    "viewSnippet": "Mostra snippet"
+  },
+  "columns": {
+    "labels": {
+      "actions": "Azioni",
+      "fragments": "Frammenti",
+      "owner": "Proprietario",
+      "title": "Titolo",
+      "updated": "Aggiornato",
+      "visibility": "Visibilità"
+    }
+  },
+  "confirmationModal": {
+    "message": "Sei sicuro di voler cancellare permanentemente questo snippet? L'azione non può esser annullata.",
+    "title": "Cancella snippet"
+  },
+  "containsOffensiveWords": "Contiene paroli offensive: {{words}}",
+  "entityName_one": "snippet",
+  "entityName_other": "snippets",
+  "error": {
+    "delete": {
+      "default": "Errore cancellazione snippet"
+    },
+    "update": {
+      "default": "Errore aggiornamento visibilità snippet"
+    }
+  },
+  "filters": {
+    "search": "Ricerca snippets...",
+    "userId": "ID Utente",
+    "visibility": {
+      "all": "Tutte le visibilità",
+      "private": "Privato",
+      "public": "Pubblico"
+    }
+  },
+  "offensiveContentMessage": "Trovati {{total}} {{entityName}} con contenuto offensivo",
+  "success": {
+    "delete": {
+      "default": "Snippet cancellato con successo"
+    },
+    "update": {
+      "default": "Visibilità Snippet aggiornata"
+    }
+  },
+  "table": {
+    "emptyMessage": "Nessun snippet trovato",
+    "loadingMessage": "Caricamento snippet..."
+  }
+}

--- a/client/src/i18n/locales/it/components/admin/tabs/users.json
+++ b/client/src/i18n/locales/it/components/admin/tabs/users.json
@@ -1,0 +1,63 @@
+{
+  "action": {
+    "activate": "Attiva Utente",
+    "deactivate": "Disattiva Utente",
+    "delete": "Cancella Utente"
+  },
+  "columns": {
+    "labels": {
+      "actions": "Azioni",
+      "apiKeysCount": "Chiavi API",
+      "authType": "Tipo Autenticazione",
+      "created": "Creato",
+      "email": "Email",
+      "lastLogin": "Ultimo Accesso",
+      "snippetsCount": "Snippets",
+      "status": "Stato",
+      "username": "Nome Utente"
+    }
+  },
+  "confirmationModal": {
+    "message": "Sei sicuro di voler cancellare questo utente? Questo cancellerà tutti i suoi snippet , chiavi api e link di condivisione . L'azione non può essere annullata.",
+    "title": "Delete user"
+  },
+  "entityName_one": "utente",
+  "entityName_other": "usenti",
+  "error": {
+    "delete": {
+      "default": "Errore cancellazione utente"
+    },
+    "update": {
+      "default": "Errore aggiornamento utente"
+    }
+  },
+  "filters": {
+    "authType": {
+      "all": "Tutti i tipi di autenticazione",
+      "internal": "Interno",
+      "oidc": "OIDC"
+    },
+    "search": "Ricerca utenti...",
+    "status": {
+      "active": "Attivo",
+      "all": "Tutti gli stati",
+      "inactive": "Disattivo"
+    }
+  },
+  "status": {
+    "active": "Attivo",
+    "inactive": "Disattivo"
+  },
+  "success": {
+    "delete": {
+      "default": "Utente cancellato con successo"
+    },
+    "update": {
+      "default": "Utente Aggiornato con successo"
+    }
+  },
+  "table": {
+    "emptyMessage": "Nessun utente trovato",
+    "loadingMessage": "Caricamento utenti..."
+  }
+}

--- a/client/src/i18n/locales/it/components/auth.json
+++ b/client/src/i18n/locales/it/components/auth.json
@@ -1,0 +1,90 @@
+{
+  "apiKeysModal": {
+    "created": "Creato",
+    "createKey": "Crea chiave API",
+    "deleteApiKey": "Cancella chiave API ",
+    "enterKeyName": "Digita nome chiave",
+    "lastUsed": "Ultimo utilizzo",
+    "newApiKey": "Nuova chiave API (copiala ora, non verrà più mostrata)",
+    "notApiKeys": "Nessuna chiave API trovata",
+    "title": "Chiavi API",
+    "yourApiKeys": "Le tue chiavi API"
+  },
+  "authProvider": {
+    "error": {
+      "failedCreateAnonymousSession": "Errore inizializzazione sessione anonima"
+    },
+    "info": {
+      "logoutSuccess": "Logout effettuato con successo"
+    }
+  },
+  "changePasswordModal": {
+    "confirmNewPassword": "Conferma nuova password",
+    "currentPassword": "Password attuale",
+    "error": {
+      "default": "Errore cambio password",
+      "newPasswordMustBeAtLeastCharacters": "La nuova password deve avere come minimo {{minLength}} caratteri",
+      "newPasswordsDoNotMatch": "Le nuove password non corrispondono"
+    },
+    "newPassword": "Nuova password",
+    "passwordChangedSuccessfully": "Password cambiata con successo",
+    "process": "Cambio password in corso...",
+    "title": "Cambia password"
+  },
+  "login": {
+    "account": "account",
+    "browsePublicSnippets": "esplora snippet pubblici",
+    "create": "crea un",
+    "error": {
+      "invalidUsernameOrPassword": "Nome utente o password non valido"
+    },
+    "orContinueWithPassword": "O continua senza password",
+    "pleaseSignInToContinue": "Accedi per continuare",
+    "signingIn": "Accesso in corso..."
+  },
+  "oidc": {
+    "error": {
+      "auth_failed": "Autenticazione fallita. Può esser per un tentativo di accesso annullato o per una sessione scaduta. Riprova.",
+      "config_error": "C'è un errore nella configurazione SSO. Contatta l'amministratore.",
+      "default": "Errore durante l'autenticazione. Riprova.",
+      "provider_error": "Il provider dell'identità ha riscontrato un errore o non è più disponibile. Riprova o contatta l'amministratore.",
+      "registration_disabled": "La registrazione di nuovi account è attualmente disabilitata su questa istanza di Bytestash. Contatta l'amministratore."
+    }
+  },
+  "register": {
+    "browsePublicSnippets": "esplora snippet pubblici",
+    "creatingAccount": "Creazione Account in corso...",
+    "disabled": {
+      "description": "La registrazione di nuovi account è attualmente disabilitata.",
+      "link": {
+        "text": "Ritorna al Login"
+      },
+      "title": "Registrazione Disabilitata"
+    },
+    "error": {
+      "default": "Errore durante la Registrazione",
+      "passwordsDoNotMatch": "Le password non corrispondono"
+    },
+    "firstAccountDescription": "Questo è il primo account ad esser creato. Tutti gli snippet esistenti verranno automaticamente migrati su questo account.",
+    "notAvailable": {
+      "description": "La registrazione dell'account è disabilitata e nessun SSO provider è stato configurato. Contatta l'amministratore.",
+      "title": "Registrazione Non Disponibile"
+    },
+    "signInToYourAccount": "accedi col tuo account",
+    "title": "Crea Account"
+  },
+  "signIn": {
+    "completing": "Completamento accesso in corso...",
+    "with": "Accesso come {{displayName}}"
+  },
+  "signOut": {
+    "completing": "Completamento uscita in corso..."
+  },
+  "userDropdown": {
+    "adminPanel": "Pannello Amministratore",
+    "apiKeys": "Chiavi API",
+    "changePassword": "Cambia Password",
+    "signIn": "Accedi",
+    "signOut": "Esci"
+  }
+}

--- a/client/src/i18n/locales/it/components/categories.json
+++ b/client/src/i18n/locales/it/components/categories.json
@@ -1,0 +1,12 @@
+{
+  "categoryList": {
+    "moreCount": "{{moreCount}} ancora",
+    "noData": "Nessuna categoria",
+    "showLess": "Mostra meno"
+  },
+  "categorySuggestions": {
+    "addNewLabel": "Aggiungi nuova",
+    "placeholder": "Digita per cercare categorie...",
+    "title": "Categorie"
+  }
+}

--- a/client/src/i18n/locales/it/components/common/buttons.json
+++ b/client/src/i18n/locales/it/components/common/buttons.json
@@ -1,0 +1,71 @@
+{
+  "copyButton": {
+    "title": "Copia negli appunti"
+  },
+  "downloadArchiveButton": {
+    "error": {
+      "failedDownload": "Errore download archivio"
+    },
+    "fileLabel_one": "{{count, number}} file",
+    "fileLabel_other": "{{count, number}} file",
+    "label": "Scarica tutto",
+    "success": {
+      "downloadedAll": "Tutti i frammenti di codice son stati scaricati"
+    },
+    "title": "Scarica tutto come archivio ZIP"
+  },
+  "downloadButton": {
+    "error": {
+      "failedDownload": "Errore download del file"
+    },
+    "success": {
+      "downloaded": "\"{{fileName}}\" scaricato con successo"
+    },
+    "title": "Scarica {{fileName}}",
+    "warning": {
+      "nothing": "Niente da scaricare"
+    }
+  },
+  "exportButton": {
+    "title": "Esporta come immagine",
+    "tooltip": "Esporta"
+  },
+  "exportModal": {
+    "copyClipboard": "Copia",
+    "downloadPng": "Scarica PNG",
+    "downloadSvg": "Scarica SVG",
+    "errorCopy": "Errore copia immagine",
+    "errorGenerate": "Errore generazione immagine",
+    "shareLinkedIn": "Condividi su LinkedIn",
+    "shareTwitter": "Condividi su X",
+    "successCopy": "Immagine copiata negli appunti!",
+    "title": "Esporta codice"
+  },
+  "fileUploadButton": {
+    "error": {
+      "unknown": "Errore sconosciuto"
+    },
+    "info": {
+      "duplicateDetected": "File duplicati rilevati",
+      "duplicatesDetected_one": "{{count, number}} file duplicati rilevati",
+      "duplicatesDetected_other": "{{count, number}} file duplicati rilevati"
+    },
+    "label": "Carica file di codice",
+    "loadFromUrl": {
+      "contentMaxSizeError": "La dimensione massima deve esser inferiore a {{max}}",
+      "invalidUrl": "Inserisci un URL valido",
+      "label": "Carica da URL",
+      "title": "Carica il codice da un URL (e.g., raw GitHub link)"
+    },
+    "success": {
+      "filesUploaded_one": "{{count, number}} file caricati con successo",
+      "filesUploaded_other": "{{count, number}} file caricati con successo",
+      "fileUploaded": "\"{{fileName}}\" caricato con successo",
+      "someFilesUploaded": "{{successCount}} file su {{total}} caricati con successo"
+    },
+    "title": "Carica file di codice per creare automaticamente frammenti"
+  },
+  "rawButton": {
+    "title": "Apri raw"
+  }
+}

--- a/client/src/i18n/locales/it/components/common/dropdowns.json
+++ b/client/src/i18n/locales/it/components/common/dropdowns.json
@@ -1,0 +1,6 @@
+{
+  "baseDropdown": {
+    "addNewLabel": "Aggiungi nuovo",
+    "defaultPlaceholder": "Seleziona o digita un valore"
+  }
+}

--- a/client/src/i18n/locales/it/components/common/markdown.json
+++ b/client/src/i18n/locales/it/components/common/markdown.json
@@ -1,0 +1,15 @@
+{
+  "mermaid": {
+    "copyCode": "Copy Mermaid code",
+    "downloadPNG": "Download as PNG",
+    "downloadSVG": "Download as SVG",
+    "exitFullscreen": "Exit fullscreen",
+    "fullscreen": "Fullscreen",
+    "renderError": "Failed to render Mermaid diagram:",
+    "renderErrorFallback": "Error rendering diagram",
+    "resetView": "Reset view",
+    "title": "Mermaid Diagram",
+    "zoomIn": "Zoom in",
+    "zoomOut": "Zoom out"
+  }
+}

--- a/client/src/i18n/locales/it/components/common/modals.json
+++ b/client/src/i18n/locales/it/components/common/modals.json
@@ -1,0 +1,7 @@
+{
+  "changelogModal": {
+    "error": {
+      "default": "Errore caricamento changelog. Riprova più tardi."
+    }
+  }
+}

--- a/client/src/i18n/locales/it/components/search.json
+++ b/client/src/i18n/locales/it/components/search.json
@@ -1,0 +1,30 @@
+{
+  "action": {
+    "clear": "Cancella ricerca",
+    "newSnippet": "Nuovo snippet",
+    "openSettings": "Apri impostazioni",
+    "recycleBin": "Cestino",
+    "showAll": "Mostra tutto",
+    "showFavorites": "Mostra preferiti"
+  },
+  "categories": {
+    "addNew": "Aggiungi Nuovo",
+    "title": "Categorie"
+  },
+  "defaultPlaceholder": "Ricerca snippet... (Digita # per vedere tutte le categorie disponibili)",
+  "filter": {
+    "language": {
+      "all": "Tutti i linguaggi"
+    }
+  },
+  "sort": {
+    "alphaAsc": "Alfabeticamente A-Z",
+    "alphaDesc": "Alfabeticamente Z-A",
+    "newestFirst": "Più recenti prima",
+    "oldestFirst": "Più vecchie prima"
+  },
+  "view": {
+    "grid": "Visione a griglia",
+    "list": "Visione a lista"
+  }
+}

--- a/client/src/i18n/locales/it/components/settings.json
+++ b/client/src/i18n/locales/it/components/settings.json
@@ -1,0 +1,93 @@
+{
+  "settingsModal": {
+    "block": {
+      "category": {
+        "expandCategories": {
+          "description": "Espandi automaticamente i gruppi di categorie",
+          "label": "Espandi Categorie"
+        },
+        "showCategories": {
+          "description": "Mostra etichette categorie sugli snippet",
+          "label": "Mostra Categorie"
+        },
+        "title": "Categoria"
+      },
+      "dataManagement": {
+        "export": {
+          "label": "Esporta Snippet"
+        },
+        "import": {
+          "errors": {
+            "failed": "Errore importazione snippet \"{{title}}\": {{error}}",
+            "occurred_one": "{{count, number}} errori rilevati",
+            "occurred_other": "{{count, number}} errori rilevati"
+          },
+          "label": "Importa Snippet",
+          "progress": "Importazione snippet in corso..."
+        },
+        "title": "Gestione Dati"
+      },
+      "locale": {
+        "title": "Locale"
+      },
+      "search": {
+        "includeCodeInSearch": {
+          "description": "Ricerca anche all'interno del contenuto del codice, non solo i titoli",
+          "label": "Includi Codice nella ricerca"
+        },
+        "title": "Ricerca"
+      },
+      "theme": {
+        "title": "Tema"
+      },
+      "view": {
+        "compactView": {
+          "description": "Mostra snippet in un formato più compatto",
+          "label": "Visione Compatta"
+        },
+        "previewLines": {
+          "description": "Mostra una preview del codice nella lista snippet",
+          "label": "Mostra Preview Codice"
+        },
+        "showCodePreview": {
+          "description": "Massimo numero di linee da mostrare nella preview (1-20)",
+          "label": "Numero di Linee nella Preview"
+        },
+        "showLineNumbers": {
+          "description": "Mostra numero linea nei blocchi codice",
+          "label": "Mostra Numero Linee"
+        },
+        "title": "Mostra"
+      }
+    },
+    "export": {
+      "error": {
+        "default": "Errore Esportazione snippet",
+        "noSnippets": "Nessun snippet disponibile per l'esportazione"
+      },
+      "markdown": {
+        "error": {
+          "default": "Errore esportazione Markdown"
+        },
+        "success": {
+          "default": "Markdown esportato con successo"
+        },
+        "warning": {
+          "default": "Nessun snippet disponibile per l'esportazione"
+        }
+      },
+      "success": {
+        "default": "{{total}} snippet esportati con successo"
+      }
+    },
+    "import": {
+      "error": {
+        "default": "Errore importazione snippet"
+      },
+      "hasFailed": "Importati {{succeeded}} snippet, {{failed}} hanno dato errore. Controlla la console per i dettagli.",
+      "successOnly_one": "Importati con successo {{succeeded}} snippet. Chiudi le impostazioni per vederli.",
+      "successOnly_other": "Importati con successo {{succeeded}} snippet. Chiudi le impostazioni per vederli."
+    },
+    "title": "Impostazioni"
+  }
+}

--- a/client/src/i18n/locales/it/components/snippets/edit.json
+++ b/client/src/i18n/locales/it/components/snippets/edit.json
@@ -1,0 +1,63 @@
+{
+  "editSnippetModal": {
+    "addSnippet": "Aggiungi nuovo snippet",
+    "editSnippet": "Modifica snippet",
+    "error": {
+      "savingFailed": "Errore durante il salvataggio dello snippet. Riprova."
+    },
+    "form": {
+      "categories": {
+        "counter": "{{categories}}/{{max}} categorie",
+        "label": "Categorie (massime {{max}})",
+        "placeholder": "Digita una categoria e premi 'Invio' o 'Virgola'"
+      },
+      "codeFragments": {
+        "add": "Aggiungi nuovo frammento",
+        "label": "Frammenti di codice ({{fragments}})"
+      },
+      "description": {
+        "label": "Descrizione",
+        "placeholder": "Scrivi una breve descrizione del tuo snippet"
+      },
+      "isPublic": {
+        "description": "Gli snippet pubblici possono esser visibili da chiunque, anche senza autenticazione",
+        "label": "Rendi snippet pubblico"
+      },
+      "title": {
+        "counter": "{{characters}}/{{max}} caratteri",
+        "label": "Titolo",
+        "placeholder": "Digita il titolo del tuo snippet (massimo {{max}} caratteri)"
+      }
+    },
+    "fragmentRequired": "Almeno un frammento di codice è richiesto",
+    "mustHaveFileNames": "Tutti i frammenti devono avere un nome",
+    "unsavedChanges": "Hai modifiche non salvate. Sei sicuro di voler chiudere?"
+  },
+  "searchFiles": "Ricerca file...",
+  "noFilesFound": "Nessun file corrisponde alla ricerca",
+  "expandSidebar": "Espandi Barra Laterale",
+  "filterFiles": "Filtra file",
+  "fileExtensions": "Estensione File",
+  "noExtension": "Nessuna estensione",
+  "fragmentEditor": {
+    "action": {
+      "collapse": "Riduci",
+      "delete": "Cancella",
+      "expand": "Espandi"
+    },
+    "form": {
+      "fileName": {
+        "placeholder": "Nome File"
+      },
+      "language": {
+        "placeholder": "Selezione Linguaggio",
+        "sections": {
+          "other": "Altri",
+          "used": "Usati"
+        }
+      }
+    },
+    "moveDown": "Muovi sopra",
+    "moveUp": "Muovi sotto"
+  }
+}

--- a/client/src/i18n/locales/it/components/snippets/embed.json
+++ b/client/src/i18n/locales/it/components/snippets/embed.json
@@ -1,0 +1,26 @@
+{
+  "embedCopyButton": {
+    "title": "Copia negli appunti"
+  },
+  "embedModal": {
+    "form": {
+      "embedCode": "Embed Codice",
+      "fragmentToShow": {
+        "all": "Tutti i frammenti",
+        "label": "Frammenti da mostrare (opzionale)"
+      },
+      "showDescription": "Mostra descrizione",
+      "showFileHeaders": "Mostra headers del file",
+      "showPoweredBy": "Mostra \"Offero da ByteStash\"",
+      "showTitle": "Mostra Titolo",
+      "theme": "Tema"
+    },
+    "subTitle": "Personalizza Embed",
+    "title": "Embed Snippet"
+  },
+  "embedView": {
+    "error": {
+      "default": "Errore caricamento snippet"
+    }
+  }
+}

--- a/client/src/i18n/locales/it/components/snippets/list/snippetCard.json
+++ b/client/src/i18n/locales/it/components/snippets/list/snippetCard.json
@@ -1,0 +1,37 @@
+{
+  "confirmationModalDelete": {
+    "confirmLabel": {
+      "isRecycleView": {
+        "false": "Sposta nel Cestino",
+        "true": "Cancella permanentemente"
+      }
+    },
+    "message": {
+      "isRecycleView": {
+        "false": "Sei sicuro di voler spostare \"{{title}}\" nel Cestino?",
+        "true": "Sei sicuro di voler cancellare permanentemente \"{{title}}\"? L'azione non può essere annullata."
+      }
+    },
+    "title": {
+      "isRecycleView": {
+        "false": "Sposta nel Cestino",
+        "true": "Conferma cancellazione"
+      }
+    }
+  },
+  "confirmationModalRestore": {
+    "message": "Sei sicuro di voler ripristinare \"{{title}}\"?",
+    "title": "Conferma ripristino"
+  },
+  "date": {
+    "ago": "{{date}} fa",
+    "expiringSoon": "in scadenza",
+    "left": "{{date}} mancanti"
+  },
+  "defaultDescription": "Nessuna descrizione disponibile",
+  "defaultUpdateTime": "Sconosciuto",
+  "favorite": "Preferito",
+  "pinned": "Fissato",
+  "public": "Publico",
+  "shared": "Condiviso"
+}

--- a/client/src/i18n/locales/it/components/snippets/list/snippetCardMenu.json
+++ b/client/src/i18n/locales/it/components/snippets/list/snippetCardMenu.json
@@ -1,0 +1,11 @@
+{
+  "addToFavorites": "Aggiungi ai preferiti",
+  "deleteSnippet": "Cancella snippet",
+  "duplicateSnippet": "Duplica snippet",
+  "editSnippet": "Modifica snippet",
+  "openInNewTab": "Apri in una nuova scheda",
+  "pinSnippet": "Fissa snippet",
+  "removeFromFavorites": "Rimuovi dai preferiti",
+  "shareSnippet": "Condivi snippet",
+  "unpinSnippet": "Rimuovi snippet dai fissati"
+}

--- a/client/src/i18n/locales/it/components/snippets/list/snippetList.json
+++ b/client/src/i18n/locales/it/components/snippets/list/snippetList.json
@@ -1,0 +1,3 @@
+{
+  "noSnippetsMatch": "Nessun snippet corrisponde ai tuoi criteri di ricerca"
+}

--- a/client/src/i18n/locales/it/components/snippets/list/snippetRecycleCardMenu.json
+++ b/client/src/i18n/locales/it/components/snippets/list/snippetRecycleCardMenu.json
@@ -1,0 +1,4 @@
+{
+  "deleteSnippet": "Cancella snippet",
+  "restoreSnippet": "Ripristina snippet"
+}

--- a/client/src/i18n/locales/it/components/snippets/share.json
+++ b/client/src/i18n/locales/it/components/snippets/share.json
@@ -1,0 +1,48 @@
+{
+  "sharedSnippetView": {
+    "browsePublicSnippets": "Esplora snippet pubblici",
+    "loadingSnippet": "Caricamento snippet...",
+    "snippetExpired": "Questo snippet condiviso è scaduto",
+    "snippetNotFound": "Snippet non trovato"
+  },
+  "shareMenu": {
+    "activeShareLinks": {
+      "buttons": {
+        "copy": "Copia Link",
+        "delete": "Cancella link di condivisione",
+        "requiresAuth": {
+          "false": "Embed snippet",
+          "true": "L'azione può esser eseguita solo su snippet pubblici"
+        }
+      },
+      "date": {
+        "expired": "Scaduto",
+        "neverExpires": "Senza Scadenza"
+      },
+      "noLinks": "Nessun link di condivisione attivo",
+      "relativeExpiryTime": "Scade : {{date}}",
+      "requiresAuth": {
+        "false": "Accesso Pubblico",
+        "true": "Protetto - Autenticazione Richiesta"
+      },
+      "title": "Link di condivisione attivi"
+    },
+    "createButtonText": "Crea Link di condivisione",
+    "error": {
+      "created": "Errore creazione link di condivisione",
+      "deleted": "Errore cancellazione link di condivisione",
+      "invalidDuration": "Formata durata non valido. Usa: 1h, 2d, 30m etc.",
+      "load": "Errore caricamento snippet condivisi",
+      "unknownExpiryTime": "Data di scadenza sconosciuta"
+    },
+    "expiresIn": "Scade tra (es. 1h, 2d, 30m)",
+    "expiresInPlaceholder": "Mai",
+    "requiresAuth": "Autenticazione Richiesta",
+    "subTitle": "Crea nuovo link di condivisione",
+    "success": {
+      "created": "Link di condivisione creato",
+      "deleted": "Link di condivisione cancellato"
+    },
+    "title": "Condividi Snippet"
+  }
+}

--- a/client/src/i18n/locales/it/components/snippets/view/all.json
+++ b/client/src/i18n/locales/it/components/snippets/view/all.json
@@ -1,0 +1,36 @@
+{
+  "fullCodeView": {
+    "dateTimeAgo": "{{dateTime}} fa",
+    "defaultDescription": "Nessuna descrizione disponibile"
+  },
+  "files": "file",
+  "collapseSidebar": "Collassa Barra Laterale",
+  "expandSidebar": "Espandi Barra Laterale",
+  "searchFiles": "Ricerca file...",
+  "noFilesFound": "Nessun file corrisponde alla tua ricerca",
+  "filterFiles": "Filtra file",
+  "fileExtensions": "Estensioni file",
+  "noExtension": "Nessuna Estensione",
+  "snippetModal": {
+    "confirmationModal": {
+      "confirmLabel": {
+        "isRecycleView": {
+          "false": "Sposta nel Cestino",
+          "true": "Cancella permanentemente"
+        }
+      },
+      "message": {
+        "isRecycleView": {
+          "false": "Sei sicuro di voler spostare \"{{title}}\" nel Cestino?",
+          "true": "Sei sicuro di voler cancellare permanentemente \"{{title}}\"? L'azione non può essere annullata."
+        }
+      },
+      "title": {
+        "isRecycleView": {
+          "false": "Sposta nel Cestino",
+          "true": "Conferma Cancellazione"
+        }
+      }
+    }
+  }
+}

--- a/client/src/i18n/locales/it/components/snippets/view/common.json
+++ b/client/src/i18n/locales/it/components/snippets/view/common.json
@@ -1,0 +1,56 @@
+{
+  "authAwareSnippetView": {
+    "error": {
+      "snippetLoad": "Errore caricamento snippet",
+      "snippetRequireAuth": "Questo snippet richiede l'autenticazione per esser mostrato"
+    }
+  },
+  "baseSnippetStorage": {
+    "error": {
+      "sessionExpired": "Sessione scaduta. Effettuare nuovamente l'accesso.",
+      "snippetCreated": "Errore creazione snippet",
+      "snippetUpdated": "Errore aggiornamento snippet"
+    },
+    "success": {
+      "displayAll": "Mostrando tutti gli snippet",
+      "displayFavorites": "Mostrando snippet preferiti",
+      "snippetCreated": "Nuovo snippet creato con successo",
+      "snippetUpdated": "Snippet aggiornato con successo"
+    }
+  },
+  "browsePublicSnippets": "Esplora snippet pubblici",
+  "filter": {
+    "filteredByCategories": "Filtra per categorie"
+  },
+  "loadingSnippets": "Caricamento snippet...",
+  "signIn": "Accedi",
+  "sippetNotFound": "Snippet non trovato",
+  "snippetContentArea": {
+    "error": {
+      "duplicateSnippet": "Errore duplicazione snippet",
+      "loadSnippets": "Errore caricamento snippet",
+      "moveSnippetToRecycleBin": "Errore spostamento snippet nel Cestino. Riprova.",
+      "sessionExpired": "Sessione scaduta. Effettua nuovamente l'accesso.",
+      "updateFavoriteStatusAdded": "Errore salvataggio snippet fra i preferiti. Riprova.",
+      "updateFavoriteStatusDeleted": "Errore rimozione snippet dai preferiti. Riprova.",
+      "updatePinStatusAdded": "Errore fissaggio snippet. Riprova.",
+      "updatePinStatusDeleted": "Errore rimozione snippet dai fissati. Riprova."
+    },
+    "success": {
+      "duplicateSnippet": "Snippet duplicato con successo",
+      "moveSnippetToRecycleBin": "Snippet spostato nel Cestino con successo",
+      "updateFavoriteStatusAdded": "Snippet aggiunto ai preferiti con successo",
+      "updateFavoriteStatusDeleted": "Snippet rimosso dai preferiti con successo",
+      "updatePinStatusAdded": "Snippet fissatto con successo",
+      "updatePinStatusDeleted": "Rimozione Snippet dai fissati eseguita con successo"
+    }
+  },
+  "storageHeader": {
+    "private": "Stai guardando i tuoi snippet privati. Solo tu puoi vedere e modificare questi snippet.",
+    "public": "Stai guardando snippet pubblicamente accessibili. Questi snippet sono di sola visione e visibili a chiunque."
+  },
+  "viewSwitch": {
+    "private": "Privato",
+    "public": "Pubblico"
+  }
+}

--- a/client/src/i18n/locales/it/components/snippets/view/public.json
+++ b/client/src/i18n/locales/it/components/snippets/view/public.json
@@ -1,0 +1,18 @@
+{
+  "publicSnippetContentArea": {
+    "error": {
+      "addSnippetToCollection": "Errore aggiunta snippet alla tua collezione",
+      "failedLoadSnippets": "Errore caricamento snippet pubblici"
+    },
+    "filter": {
+      "byCategories": "Filtra per categoria"
+    },
+    "info": {
+      "requireAuth": "Effettua l'accesso per aggiungere snippet alla tua collezione"
+    },
+    "loadingSnippets": "Caricamento snippet...",
+    "success": {
+      "addSnippetToCollection": "Snippet aggiunto alla tua collezione"
+    }
+  }
+}

--- a/client/src/i18n/locales/it/components/snippets/view/recycle.json
+++ b/client/src/i18n/locales/it/components/snippets/view/recycle.json
@@ -1,0 +1,37 @@
+{
+  "recycleSnippetContentArea": {
+    "error": {
+      "deleteSnippet": "Errore cancellazione snippet",
+      "loadSnippets": "Errore Caricamento snippet",
+      "restoreSnippet": "Errore ripristino snippet",
+      "sessionExpired": "Sessione Scaduta. Effettua nuovamente l'accesso."
+    },
+    "filter": {
+      "byCategories": "Filtra per categorie"
+    },
+    "loadingSnippets": "Caricamento snippet...",
+    "success": {
+      "deleteSnippet": "Snippet cancellato con successo",
+      "restoreSnippet": "Snippet ripristinato con successo"
+    }
+  },
+  "recycleSnippetStorage": {
+    "backToSnippets": "Torna agli Snippet",
+    "confirmationModal": {
+      "message": "Sei sicuro di voler cancellare permanentemente tutti gli snippet nel cestino? Questa azione non può esser annullata.",
+      "title": "Conferma Cancellazione"
+    },
+    "description": "Gli Snippet nel Cestino verranno cancellati permanentemente automaticamente dopo 30 giorni",
+    "error": {
+      "clear": "Errore svuotamento cestino. Riprova.",
+      "sessionExpired": "Sessione Scaduta. Effettua nuovamente l'accesso."
+    },
+    "info": {
+      "noSnippets": "Cestino vuoto"
+    },
+    "recycleBin": "Cestino",
+    "success": {
+      "clear": "Il cestino è stato svuotato"
+    }
+  }
+}

--- a/client/src/i18n/locales/it/components/utils.json
+++ b/client/src/i18n/locales/it/components/utils.json
@@ -1,0 +1,9 @@
+{
+  "config": {
+    "caution": "Attenzione",
+    "important": "Importante",
+    "note": "Nota",
+    "tip": "Suggerimento",
+    "warning": "Avviso"
+  }
+}

--- a/client/src/i18n/locales/it/translation.json
+++ b/client/src/i18n/locales/it/translation.json
@@ -1,0 +1,54 @@
+{
+  "action": {
+    "addSnippet": "Aggiungi snippet",
+    "cancel": "Annulla",
+    "changePassword": "Cambia password",
+    "clear": "Cancella",
+    "clearAll": "Cancella tutto",
+    "close": "Chiudi",
+    "confirm": "Conferma",
+    "createAccount": "Crea account",
+    "delete": "Cancella",
+    "edit": "Modifica",
+    "hidePassword": "Nascondi password",
+    "load": "Carica",
+    "maximize": "Ingrandisci",
+    "minimize": "Minimizza",
+    "restore": "Ripristina",
+    "save": "Salva",
+    "saving": "Salvataggio in corso...",
+    "showPassword": "Mostra password",
+    "signIn": "Accedi"
+  },
+  "confirmPassword": "Conferma Password",
+  "loading": "Caricamento in corso...",
+  "locale": {
+    "en": "Inglese",
+    "es": "Spagnolo",
+    "ja": "Giapponese",
+    "ru": "Russo",
+    "it":"Italian"
+  },
+  "no": "no",
+  "or": "oppure",
+  "pagination": {
+    "next": "Prossima",
+    "pageOf": "Pagina {{currentPage}} di {{totalPages}}",
+    "previous": "Precedente",
+    "total": "{{total}} totali",
+    "useSnippetPagination": {
+      "error": {
+        "failedSnippetsLoad": "Errore caricamento snippet",
+        "sessionExpired": "Sessione scaduta. Effettua nuovamente l'accesso"
+      }
+    }
+  },
+  "password": "Password",
+  "showing": "Mostrando",
+  "theme": {
+    "dark": "Scuro",
+    "light": "Bianco",
+    "system": "Sistema"
+  },
+  "username": "Nome Utente"
+}

--- a/client/src/i18n/resources/index.ts
+++ b/client/src/i18n/resources/index.ts
@@ -3,6 +3,7 @@ import { resources as ruResources } from './ru';
 import { resources as esResources } from './es';
 import { resources as jaResources } from './ja';
 import { resources as zhResources } from './zh';
+import { resources as itResources } from './it';
 
 export const resources = {
   en: enResources,
@@ -10,4 +11,5 @@ export const resources = {
   es: esResources,
   ja: jaResources,
   zh: zhResources,
+  it: itResources
 };

--- a/client/src/i18n/resources/it.ts
+++ b/client/src/i18n/resources/it.ts
@@ -1,0 +1,61 @@
+import translation from '../locales/it/translation.json'
+import componentsAdminCommon from '../locales/it/components/admin/common.json'
+import componentsAdminModals from '../locales/it/components/admin/modals.json'
+import componentsAdminSelector from '../locales/it/components/admin/selector.json'
+import componentsAdminApiKeysTab from '../locales/it/components/admin/tabs/apiKeys.json'
+import componentsAdminUsersTab from '../locales/it/components/admin/tabs/users.json'
+import componentsAdminSharesTab from '../locales/it/components/admin/tabs/shares.json'
+import componentsAdminSnippetsTab from '../locales/it/components/admin/tabs/snippets.json'
+import componentsAdminDashboardTab from '../locales/it/components/admin/tabs/dashboard.json'
+import componentsAuth from '../locales/it/components/auth.json'
+import componentsCategories from '../locales/it/components/categories.json'
+import componentsCommonButtons from '../locales/it/components/common/buttons.json'
+import componentsCommonDropdowns from '../locales/it/components/common/dropdowns.json'
+import componentsCommonModals from '../locales/it/components/common/modals.json'
+import componentsSearch from '../locales/it/components/search.json'
+import componentsSettings from '../locales/it/components/settings.json'
+import componentsSnippetsEdit from '../locales/it/components/snippets/edit.json'
+import componentsSnippetsEmbed from '../locales/it/components/snippets/embed.json'
+import componentsSnippetsListSnippetCard from '../locales/it/components/snippets/list/snippetCard.json'
+import componentsSnippetsListSnippetCardMenu from '../locales/it/components/snippets/list/snippetCardMenu.json'
+import componentsSnippetsListSnippetList from '../locales/it/components/snippets/list/snippetList.json'
+import componentsSnippetsListSnippetRecycleCardMenu from '../locales/it/components/snippets/list/snippetRecycleCardMenu.json'
+import componentsSnippetsShare from '../locales/it/components/snippets/share.json'
+import componentsSnippetsViewAll from '../locales/it/components/snippets/view/all.json'
+import componentsSnippetsViewCommon from '../locales/it/components/snippets/view/common.json'
+import componentsSnippetsViewPublic from '../locales/it/components/snippets/view/public.json'
+import componentsSnippetsViewRecycle from '../locales/it/components/snippets/view/recycle.json'
+import componentsCommonMarkdown from '../locales/it/components/common/markdown.json'
+import componentsUtils from '../locales/it/components/utils.json'
+
+export const resources = {
+  translation,
+  'components/admin/common': componentsAdminCommon,
+  'components/admin/modals': componentsAdminModals,
+  'components/admin/selector': componentsAdminSelector,
+  'components/admin/tabs/apiKeys': componentsAdminApiKeysTab,
+  'components/admin/tabs/users': componentsAdminUsersTab,
+  'components/admin/tabs/shares': componentsAdminSharesTab,
+  'components/admin/tabs/snippets': componentsAdminSnippetsTab,
+  'components/admin/tabs/dashboard': componentsAdminDashboardTab,
+  'components/auth': componentsAuth,
+  'components/categories': componentsCategories,
+  'components/common/buttons': componentsCommonButtons,
+  'components/common/dropdowns': componentsCommonDropdowns,
+  'components/common/markdown': componentsCommonMarkdown,
+  'components/common/modals': componentsCommonModals,
+  'components/search': componentsSearch,
+  'components/settings': componentsSettings,
+  'components/snippets/edit': componentsSnippetsEdit,
+  'components/snippets/embed': componentsSnippetsEmbed,
+  'components/snippets/list/snippetCard': componentsSnippetsListSnippetCard,
+  'components/snippets/list/snippetCardMenu': componentsSnippetsListSnippetCardMenu,
+  'components/snippets/list/snippetList': componentsSnippetsListSnippetList,
+  'components/snippets/list/snippetRecycleCardMenu': componentsSnippetsListSnippetRecycleCardMenu,
+  'components/snippets/share': componentsSnippetsShare,
+  'components/snippets/view/all': componentsSnippetsViewAll,
+  'components/snippets/view/common': componentsSnippetsViewCommon,
+  'components/snippets/view/public': componentsSnippetsViewPublic,
+  'components/snippets/view/recycle': componentsSnippetsViewRecycle,
+  'components/utils': componentsUtils,
+};

--- a/client/src/i18n/types.ts
+++ b/client/src/i18n/types.ts
@@ -4,4 +4,5 @@ export enum Locale {
   es = 'es',
   ja = 'ja',
   zh = 'zh',
+  it = 'it'
 }


### PR DESCRIPTION
Added Italian (it) localization for the application.

[x] Created new translation files
[x] Added it configuration to existing localization settings
[x] Verified that Italian text displays correctly
[x] Confirmed no layout breakage after switching languages

I've tested localization deploying my branch on huggingface: italian was selected automatically and no lines seems to be broken ( i've added also chinese and italian lines in traslation.json file ) 
Here's some screenshots: 
https://i.imgur.com/3JTBbHq.png
https://i.imgur.com/PcA5KUx.png
https://i.imgur.com/RaeP0AL.png