### PR TITLE
[fix] OIDC logout and login error for Google SSO

### DIFF
--- a/client/src/components/auth/oidc/OIDCCallback.tsx
+++ b/client/src/components/auth/oidc/OIDCCallback.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../../../hooks/useAuth';
@@ -13,8 +13,12 @@ export const OIDCCallback: React.FC = () => {
   const { login } = useAuth();
   const { addToast } = useToast();
   const handleOIDCError = useOidcErrorHandler();
+  const processedRef = useRef(false);
 
   useEffect(() => {
+    if (processedRef.current) return;
+    processedRef.current = true;
+
     const params = new URLSearchParams(window.location.search);
     const token = params.get('token');
     const error = params.get('error');

--- a/client/src/components/auth/oidc/OIDCLogoutCallback.tsx
+++ b/client/src/components/auth/oidc/OIDCLogoutCallback.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../../../hooks/useAuth';
@@ -9,8 +9,12 @@ export const OIDCLogoutCallback: React.FC = () => {
   const { t: translate } = useTranslation('components/auth');
   const navigate = useNavigate();
   const { logout } = useAuth();
+  const processedRef = useRef(false);
 
   useEffect(() => {
+      if (processedRef.current) return;
+      processedRef.current = true;
+
       logout();
       navigate('/', { replace: true });
   }, [logout]);

--- a/server/src/oidc/oidcConfig.js
+++ b/server/src/oidc/oidcConfig.js
@@ -129,11 +129,19 @@ class OIDCConfig {
   }
 
   async getLogoutUrl(baseUrl, id_token) {
+    const metadata = this.config.serverMetadata();
+
+    if (!metadata.end_session_endpoint) {
+      Logger.debug('Provider does not support end_session_endpoint, using local-only logout');
+      return null;
+    }
+
     const callback_url = this.getCallbackLogoutUrl(baseUrl);
     const decoded = jwt.verify(id_token, JWT_SECRET);
 
     if (!decoded.id_token) {
-      return res.status(401).json({ valid: false });
+      Logger.debug('No id_token found in JWT, using local-only logout');
+      return null;
     }
     Logger.debug(callback_url);
 

--- a/server/src/routes/oidcRoutes.js
+++ b/server/src/routes/oidcRoutes.js
@@ -74,26 +74,32 @@ router.get('/logout', async (req, res) => {
     const authHeader = req.headers.cookie;
     const token = authHeader && authHeader.split('=')[1];
 
+    // Clear the auth cookie
+    res.clearCookie('bytestash_token', { path: '/' });
+
+    // Reset logged_in state
+    oidc.loggedIn = false;
+
     if (!token) {
-      return res.status(401).json({ valid: false });
+      return res.redirect(`${process.env.BASE_PATH || ''}/auth/logout_callback`);
     }
 
     const baseUrl = getBaseUrl(req);
-    const logoutUrl = await oidc.getLogoutUrl(
-      baseUrl,
-      token // Encrpyted ID Token created when creating the IdP session
-    );
+    const logoutUrl = await oidc.getLogoutUrl(baseUrl, token);
 
-    Logger.debug('Generated Logout URL:', logoutUrl);
-
-    // Erase the OIDCConfig instance to destroy the session in the server
-    OIDCConfig.instance = null;
-
-    res.redirect(logoutUrl);
+    if (logoutUrl) {
+      Logger.debug('Generated Logout URL:', logoutUrl);
+      res.redirect(logoutUrl);
+    } else {
+      // Provider doesn't support end_session_endpoint (e.g., Google)
+      // Perform local-only logout
+      const logoutCallbackUrl = `${process.env.BASE_PATH || ''}/auth/logout_callback`;
+      res.redirect(logoutCallbackUrl);
+    }
   } catch (error) {
     Logger.error('OIDC logout error:', error);
-    const errorMessage = encodeURIComponent(error.message || 'Unknown error');
-    res.redirect(`/login?error=provider_error&message=${errorMessage}`);
+    res.clearCookie('bytestash_token', { path: '/' });
+    res.redirect(`${process.env.BASE_PATH || ''}/auth/logout_callback`);
   }
 });
 


### PR DESCRIPTION
Google's OIDC discovery document does not include an `end_session_endpoint` (RP-Initiated Logout is not supported), which breaks both logout and causes a spurious error toast on login.

## Changes

- **Logout**: Check for `end_session_endpoint` in provider metadata before calling `buildEndSessionUrl()`. When absent (e.g. Google), fall back to local-only logout (clear cookie, redirect to logout callback)
- **Logout**: Always clear the `bytestash_token` cookie on logout, including in the error path
- **Logout**: Remove `OIDCConfig.instance = null` which incorrectly destroyed the shared OIDC config on logout
- **Logout**: Fix `getLogoutUrl()` referencing `res` outside of request scope (would throw `ReferenceError`)
- **Login**: Prevent `OIDCCallback` useEffect from re-firing after URL params are consumed, which caused a false "Authentication failed" toast