### PR TITLE
Add remote MCP endpoint for AI clients (Claude, OpenAI, Perplexity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Password: demodemo
 - Create and Edit Snippets: Easily add new code snippets or update existing ones with an intuitive interface.
 - Filter by Language and Content: Quickly find the right snippet by filtering based on programming language or keywords in the content.
 - Secure Storage: All snippets are securely stored in a sqlite database, ensuring your code remains safe and accessible only to you.
+- AI Integration (MCP): Connect AI assistants such as Claude, OpenAI and Perplexity through a built-in [Model Context Protocol](https://modelcontextprotocol.io) endpoint to search and manage your snippets, authenticated with your existing API key. See [MCP (AI assistants)](#mcp-ai-assistants).
 
 ## Howto
 ### Unraid
@@ -63,6 +64,53 @@ services:
 ## API Documentation
 Once the server is running you can explore the API via Swagger UI. Open
 `/api-docs` in your browser to view the documentation for all endpoints.
+
+## MCP (AI assistants)
+ByteStash exposes a remote [Model Context Protocol](https://modelcontextprotocol.io)
+endpoint so AI assistants such as **Claude** (desktop & web), **OpenAI/ChatGPT** and
+**Perplexity** can search, read and manage your snippets directly.
+
+- **Endpoint:** `https://<your-host>/mcp` (or `https://<your-host><BASE_PATH>/mcp` when a
+  base path is configured). It is served on the same host/port as the app, so nothing extra
+  needs to be exposed in your deployment.
+- **Transport:** Streamable HTTP.
+- **Auth:** the **same API key** used by the REST API. Create one under
+  *Settings → API Keys* in the UI, then send it as `Authorization: Bearer <api-key>`
+  (or the `x-api-key` header). The MCP tools only ever access snippets owned by that key.
+
+### Available tools
+`list_snippets`, `get_snippet`, `create_snippet`, `update_snippet`, `delete_snippet`,
+`list_metadata`.
+
+### Connecting clients
+- **Claude Desktop** (`claude_desktop_config.json`):
+  ```json
+  {
+    "mcpServers": {
+      "bytestash": {
+        "type": "http",
+        "url": "https://your-host/mcp",
+        "headers": { "Authorization": "Bearer YOUR_API_KEY" }
+      }
+    }
+  }
+  ```
+- **Claude.ai / web & other custom connectors:** add a custom connector pointing at
+  `https://your-host/mcp` and supply the `Authorization: Bearer YOUR_API_KEY` header.
+- **OpenAI Responses API:** pass it as an MCP tool:
+  ```json
+  {
+    "type": "mcp",
+    "server_label": "bytestash",
+    "server_url": "https://your-host/mcp",
+    "headers": { "Authorization": "Bearer YOUR_API_KEY" }
+  }
+  ```
+- **Perplexity:** add a remote MCP connector with the URL above and the same
+  `Authorization` header.
+
+> The endpoint requires HTTPS for remote clients — terminate TLS at your reverse
+> proxy/ingress as you already do for the web UI.
 
 ## Contributing
 Contributions are welcome! Please submit a pull request or open an issue for any improvements or bug fixes.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,8 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
+      # Serves the web UI, the REST API (/api), and the remote MCP endpoint (/mcp)
+      # for AI assistants — all on the same port, authenticated with a ByteStash API key.
       - "5000:5000"
     environment:
       # e.g. write /bytestash for a domain such as my.domain/bytestash, leave blank in every other case

--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -18,6 +18,12 @@ components:
       in: header
       name: x-api-key
       description: API key for CLI access
+    BearerAuth:
+      type: http
+      scheme: bearer
+      description: >
+        ByteStash API key sent as a bearer token (Authorization: Bearer <key>).
+        Used by the MCP endpoint, which most remote MCP clients authenticate with.
   schemas:
     Fragment:
       type: object
@@ -879,3 +885,33 @@ paths:
           description: Snippet not found
         '500':
           description: Internal server error
+  /mcp:
+    post:
+      summary: Remote MCP (Model Context Protocol) endpoint for AI clients
+      description: >
+        JSON-RPC 2.0 endpoint over the MCP Streamable HTTP transport. Lets MCP-capable
+        AI clients (Claude, OpenAI, Perplexity) list, read, create, update and delete the
+        authenticated user's snippets. Authenticate with a ByteStash API key sent either as
+        `Authorization: Bearer <key>` or the `x-api-key` header. Available tools: list_snippets,
+        get_snippet, create_snippet, update_snippet, delete_snippet, list_metadata. See the
+        README "MCP (AI assistants)" section for client configuration. The request/response
+        bodies are JSON-RPC envelopes, so they are not modelled in detail here.
+      tags:
+        - MCP
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: A JSON-RPC 2.0 request (e.g. initialize, tools/list, tools/call)
+      responses:
+        '200':
+          description: JSON-RPC 2.0 response
+        '401':
+          description: Missing or invalid API key
+        '405':
+          description: Method not allowed (use POST for MCP requests)

--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
     "bad-words": "^4.0.0",
     "bcrypt": "^5.1.1",
     "better-sqlite3": "^11.5.0",
@@ -23,7 +24,8 @@
     "multer": "^1.4.5-lts.1",
     "openid-client": "^6.1.3",
     "swagger-ui-express": "^5.0.1",
-    "yamljs": "^0.3.0"
+    "yamljs": "^0.3.0",
+    "zod": "^3.23.8"
   },
   "engines": {
     "node": ">=22"

--- a/server/scripts/mcp-smoke.mjs
+++ b/server/scripts/mcp-smoke.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/*
+ * Standalone smoke test for the ByteStash MCP endpoint.
+ *
+ * It drives the JSON-RPC handshake and a full create -> list -> get -> update ->
+ * delete round trip against a *running* ByteStash server, then checks that a bad
+ * API key is rejected. No dependencies (uses global fetch); run it before opening a PR.
+ *
+ * Usage:
+ *   BYTESTASH_API_KEY=<key> node server/scripts/mcp-smoke.mjs
+ *   BYTESTASH_URL=https://my-host BYTESTASH_API_KEY=<key> node server/scripts/mcp-smoke.mjs
+ *
+ * Get an API key from the UI (Settings -> API Keys) or your instance's REST API.
+ */
+
+const BASE = (process.env.BYTESTASH_URL || 'http://localhost:5000').replace(/\/$/, '');
+const KEY = process.env.BYTESTASH_API_KEY;
+const MCP_URL = `${BASE}/mcp`;
+
+if (!KEY) {
+  console.error('Set BYTESTASH_API_KEY (and optionally BYTESTASH_URL).');
+  process.exit(2);
+}
+
+let passed = 0;
+let failed = 0;
+let rpcId = 0;
+
+function check(name, condition, detail) {
+  if (condition) {
+    passed++;
+    console.log(`  PASS  ${name}`);
+  } else {
+    failed++;
+    console.log(`  FAIL  ${name}${detail ? ` — ${detail}` : ''}`);
+  }
+}
+
+// Streamable HTTP returns either application/json or an SSE frame; handle both.
+async function readBody(res) {
+  const text = await res.text();
+  const ct = res.headers.get('content-type') || '';
+  if (ct.includes('text/event-stream')) {
+    const line = text.split('\n').find((l) => l.startsWith('data:'));
+    return line ? JSON.parse(line.slice(5).trim()) : null;
+  }
+  return text ? JSON.parse(text) : null;
+}
+
+async function rpc(method, params, { key = KEY } = {}) {
+  const res = await fetch(MCP_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      ...(key ? { Authorization: `Bearer ${key}` } : {}),
+    },
+    body: JSON.stringify({ jsonrpc: '2.0', id: ++rpcId, method, params }),
+  });
+  return { status: res.status, body: await readBody(res) };
+}
+
+// Tool results carry their payload as JSON text in content[0].text.
+function toolJson(body) {
+  const text = body?.result?.content?.[0]?.text;
+  return text ? JSON.parse(text) : null;
+}
+
+async function main() {
+  console.log(`Testing MCP endpoint: ${MCP_URL}\n`);
+
+  // 1. initialize
+  const init = await rpc('initialize', {
+    protocolVersion: '2025-06-18',
+    capabilities: {},
+    clientInfo: { name: 'mcp-smoke', version: '1.0' },
+  });
+  check('initialize returns serverInfo', init.body?.result?.serverInfo?.name === 'bytestash',
+    JSON.stringify(init.body));
+
+  // 2. tools/list
+  const list = await rpc('tools/list', {});
+  const toolNames = (list.body?.result?.tools || []).map((t) => t.name).sort();
+  const expected = ['create_snippet', 'delete_snippet', 'get_snippet', 'list_metadata', 'list_snippets', 'update_snippet'];
+  check('tools/list exposes all tools', JSON.stringify(toolNames) === JSON.stringify(expected),
+    toolNames.join(', '));
+
+  // 3. create_snippet
+  const marker = `mcp-smoke-${rpcId}`;
+  const created = toolJson((await rpc('tools/call', {
+    name: 'create_snippet',
+    arguments: {
+      title: marker,
+      description: 'created by mcp-smoke',
+      categories: ['smoke'],
+      fragments: [{ file_name: 'a.js', language: 'javascript', code: 'const x = 1;' }],
+    },
+  })).body);
+  const id = created?.id;
+  check('create_snippet returns an id', Number.isInteger(id), JSON.stringify(created));
+
+  // 4. list_snippets finds it
+  const found = toolJson((await rpc('tools/call', {
+    name: 'list_snippets', arguments: { search: marker },
+  })).body);
+  check('list_snippets finds the new snippet',
+    !!found?.snippets?.some((s) => s.id === id));
+
+  // 5. get_snippet returns the code
+  const got = toolJson((await rpc('tools/call', {
+    name: 'get_snippet', arguments: { id },
+  })).body);
+  check('get_snippet returns the fragment code',
+    got?.fragments?.[0]?.code === 'const x = 1;');
+
+  // 6. update_snippet changes the title
+  const updated = toolJson((await rpc('tools/call', {
+    name: 'update_snippet', arguments: { id, title: `${marker}-edited` },
+  })).body);
+  check('update_snippet applies partial change', updated?.title === `${marker}-edited`);
+
+  // 7. delete_snippet (recycle)
+  const deleted = toolJson((await rpc('tools/call', {
+    name: 'delete_snippet', arguments: { id },
+  })).body);
+  check('delete_snippet recycles the snippet', deleted?.id === id && deleted?.recycled === true);
+
+  // 8. auth: a bad key is rejected
+  const bad = await rpc('tools/list', {}, { key: 'definitely-not-a-real-key' });
+  check('invalid API key is rejected with 401', bad.status === 401, `got ${bad.status}`);
+
+  // 9. auth: no key is rejected
+  const none = await rpc('tools/list', {}, { key: null });
+  check('missing API key is rejected with 401', none.status === 401, `got ${none.status}`);
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  process.exit(failed ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error('\nSmoke test crashed:', err.message);
+  process.exit(1);
+});

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -9,8 +9,10 @@ import oidcRoutes from "./routes/oidcRoutes.js";
 import embedRoutes from "./routes/embedRoutes.js";
 import apiKeyRoutes from "./routes/apiKeyRoutes.js";
 import adminRoutes from "./routes/adminRoutes.js";
+import mcpRoutes from "./routes/mcpRoutes.js";
 import { authenticateToken } from "./middleware/auth.js";
 import { authenticateApiKey } from "./middleware/apiKeyAuth.js";
+import { authenticateMcp } from "./middleware/mcpAuth.js";
 import { requireAdmin } from "./middleware/adminAuth.js";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
@@ -54,6 +56,11 @@ app.use(`${basePath}/api/share`, shareRoutes);
 app.use(`${basePath}/api/public/snippets`, publicRoutes);
 app.use(`${basePath}/api/embed`, embedRoutes);
 app.use(`${basePath}/api/admin`, authenticateToken, requireAdmin, adminRoutes);
+
+// Remote MCP endpoint for AI clients (Claude, OpenAI, Perplexity). Served on the same
+// host/port as the app, authenticated with a ByteStash API key (Authorization: Bearer
+// <key> or x-api-key). Connect a client to: <base-url>${basePath}/mcp
+app.use(`${basePath}/mcp`, authenticateMcp, mcpRoutes);
 
 app.use(
   `${basePath}/manifest.json`,

--- a/server/src/mcp/snippetMcpServer.js
+++ b/server/src/mcp/snippetMcpServer.js
@@ -1,0 +1,300 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import snippetService from '../services/snippetService.js';
+import Logger from '../logger.js';
+
+/*
+ * Builds an MCP server instance scoped to a single authenticated ByteStash user.
+ *
+ * Every tool operates only on snippets owned by `userId` (the same authorization
+ * boundary the REST API enforces), so an API key never grants access beyond what
+ * that key's owner could already see through the web UI or REST API.
+ *
+ * A fresh server is created per request (stateless Streamable HTTP transport), so the
+ * userId is safely captured in the tool closures with no cross-request leakage.
+ */
+
+const fragmentInputSchema = z.object({
+  file_name: z.string().optional().describe('File name for this fragment, e.g. "index.js"'),
+  code: z.string().describe('The snippet code/content for this fragment'),
+  language: z.string().optional().describe('Language id, e.g. "javascript", "python", "plaintext"'),
+});
+
+function summarizeSnippet(snippet) {
+  return {
+    id: snippet.id,
+    title: snippet.title,
+    description: snippet.description,
+    categories: snippet.categories,
+    is_public: !!snippet.is_public,
+    is_favorite: !!snippet.is_favorite,
+    is_pinned: !!snippet.is_pinned,
+    updated_at: snippet.updated_at,
+    files: (snippet.fragments || []).map((f) => ({
+      file_name: f.file_name,
+      language: f.language,
+    })),
+  };
+}
+
+function fullSnippet(snippet) {
+  return {
+    id: snippet.id,
+    title: snippet.title,
+    description: snippet.description,
+    categories: snippet.categories,
+    is_public: !!snippet.is_public,
+    is_favorite: !!snippet.is_favorite,
+    is_pinned: !!snippet.is_pinned,
+    updated_at: snippet.updated_at,
+    fragments: (snippet.fragments || []).map((f) => ({
+      id: f.id,
+      file_name: f.file_name,
+      language: f.language,
+      position: f.position,
+      code: f.code,
+    })),
+  };
+}
+
+function ok(data) {
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+}
+
+function fail(message) {
+  return { content: [{ type: 'text', text: message }], isError: true };
+}
+
+export function createMcpServer(userId) {
+  const server = new McpServer(
+    { name: 'bytestash', version: '1.0.0' },
+    {
+      instructions:
+        'ByteStash is a code-snippet manager. Use these tools to search, read, create, ' +
+        'update and delete the authenticated user\'s code snippets. Each snippet has a title, ' +
+        'description, categories (tags), and one or more file "fragments" (each with a file name, ' +
+        'language and code). Start with list_snippets or list_metadata to discover what exists.',
+    }
+  );
+
+  server.registerTool(
+    'list_snippets',
+    {
+      title: 'List / search snippets',
+      description:
+        'List the user\'s code snippets with optional full-text search and filtering. ' +
+        'Returns a summary (no code bodies) plus pagination info. Use get_snippet to read the code.',
+      inputSchema: {
+        search: z.string().optional().describe('Free-text search over title, description and (by default) code'),
+        searchCode: z.boolean().optional().describe('Whether search also matches code content (default true)'),
+        language: z.string().optional().describe('Only snippets containing a fragment in this language'),
+        categories: z.array(z.string()).optional().describe('Only snippets that have ALL of these categories/tags'),
+        favorites: z.boolean().optional().describe('Only favorited snippets'),
+        pinned: z.boolean().optional().describe('Only pinned snippets'),
+        sort: z.enum(['newest', 'oldest', 'alpha-asc', 'alpha-desc']).optional().describe('Sort order (default newest)'),
+        limit: z.number().int().min(1).max(100).optional().describe('Max results (1-100, default 50)'),
+        offset: z.number().int().min(0).optional().describe('Pagination offset (default 0)'),
+      },
+    },
+    async (args) => {
+      try {
+        const limit = args.limit ?? 50;
+        const offset = args.offset ?? 0;
+        const { snippets, total } = await snippetService.getSnippetsPaginated({
+          userId,
+          filters: {
+            search: args.search || null,
+            searchCode: args.searchCode !== false,
+            language: args.language || null,
+            categories: args.categories && args.categories.length
+              ? args.categories.map((c) => c.trim().toLowerCase())
+              : null,
+            favorites: !!args.favorites,
+            pinned: !!args.pinned,
+            recycled: false,
+          },
+          sort: args.sort || 'newest',
+          limit,
+          offset,
+        });
+
+        return ok({
+          snippets: snippets.map(summarizeSnippet),
+          pagination: { total, offset, limit, hasMore: offset + limit < total },
+        });
+      } catch (error) {
+        Logger.error('MCP list_snippets failed:', error);
+        return fail('Failed to list snippets');
+      }
+    }
+  );
+
+  server.registerTool(
+    'get_snippet',
+    {
+      title: 'Get a snippet',
+      description: 'Fetch a single snippet by id, including the full code of every fragment.',
+      inputSchema: {
+        id: z.coerce.number().int().describe('The snippet id'),
+      },
+    },
+    async (args) => {
+      try {
+        const snippet = await snippetService.findById(args.id, userId);
+        if (!snippet) {
+          return fail(`Snippet ${args.id} not found`);
+        }
+        return ok(fullSnippet(snippet));
+      } catch (error) {
+        Logger.error('MCP get_snippet failed:', error);
+        return fail('Failed to get snippet');
+      }
+    }
+  );
+
+  server.registerTool(
+    'create_snippet',
+    {
+      title: 'Create a snippet',
+      description: 'Create a new code snippet with one or more file fragments.',
+      inputSchema: {
+        title: z.string().min(1).describe('Snippet title'),
+        description: z.string().optional().describe('Markdown description'),
+        categories: z.array(z.string()).optional().describe('Category/tag names'),
+        fragments: z.array(fragmentInputSchema).min(1).describe('One or more code files'),
+        is_public: z.boolean().optional().describe('Whether the snippet is publicly visible (default false)'),
+      },
+    },
+    async (args) => {
+      try {
+        const created = await snippetService.createSnippet(
+          {
+            title: args.title,
+            description: args.description || '',
+            categories: args.categories || [],
+            fragments: args.fragments.map((f, i) => ({
+              file_name: f.file_name || `file${i + 1}`,
+              code: f.code || '',
+              language: f.language || 'plaintext',
+              position: i,
+            })),
+            is_public: args.is_public ? 1 : 0,
+          },
+          userId
+        );
+        return ok(fullSnippet(created));
+      } catch (error) {
+        Logger.error('MCP create_snippet failed:', error);
+        return fail('Failed to create snippet');
+      }
+    }
+  );
+
+  server.registerTool(
+    'update_snippet',
+    {
+      title: 'Update a snippet',
+      description:
+        'Update an existing snippet. Only the fields you provide are changed; omitted fields keep ' +
+        'their current values. Providing "fragments" or "categories" replaces them entirely.',
+      inputSchema: {
+        id: z.coerce.number().int().describe('The snippet id to update'),
+        title: z.string().min(1).optional().describe('New title'),
+        description: z.string().optional().describe('New markdown description'),
+        categories: z.array(z.string()).optional().describe('Replacement set of category/tag names'),
+        fragments: z.array(fragmentInputSchema).min(1).optional().describe('Replacement set of code files'),
+        is_public: z.boolean().optional().describe('New public visibility'),
+      },
+    },
+    async (args) => {
+      try {
+        const existing = await snippetService.findById(args.id, userId);
+        if (!existing) {
+          return fail(`Snippet ${args.id} not found`);
+        }
+
+        const fragments = args.fragments
+          ? args.fragments.map((f, i) => ({
+              file_name: f.file_name || `file${i + 1}`,
+              code: f.code || '',
+              language: f.language || 'plaintext',
+              position: i,
+            }))
+          : existing.fragments;
+
+        const updated = await snippetService.updateSnippet(
+          args.id,
+          {
+            title: args.title ?? existing.title,
+            description: args.description ?? existing.description,
+            categories: args.categories ?? existing.categories,
+            fragments,
+            is_public: (args.is_public ?? !!existing.is_public) ? 1 : 0,
+          },
+          userId
+        );
+
+        if (!updated) {
+          return fail(`Snippet ${args.id} not found`);
+        }
+        return ok(fullSnippet(updated));
+      } catch (error) {
+        Logger.error('MCP update_snippet failed:', error);
+        return fail('Failed to update snippet');
+      }
+    }
+  );
+
+  server.registerTool(
+    'delete_snippet',
+    {
+      title: 'Delete a snippet',
+      description:
+        'Delete a snippet. By default it is moved to the recycle bin (recoverable for 30 days); ' +
+        'set permanent=true to delete it irreversibly.',
+      inputSchema: {
+        id: z.coerce.number().int().describe('The snippet id to delete'),
+        permanent: z.boolean().optional().describe('Permanently delete instead of moving to recycle bin (default false)'),
+      },
+    },
+    async (args) => {
+      try {
+        const result = args.permanent
+          ? await snippetService.deleteSnippet(args.id, userId)
+          : await snippetService.moveToRecycle(args.id, userId);
+
+        if (!result) {
+          return fail(`Snippet ${args.id} not found`);
+        }
+        return ok({
+          id: result.id,
+          deleted: !!args.permanent,
+          recycled: !args.permanent,
+        });
+      } catch (error) {
+        Logger.error('MCP delete_snippet failed:', error);
+        return fail('Failed to delete snippet');
+      }
+    }
+  );
+
+  server.registerTool(
+    'list_metadata',
+    {
+      title: 'List snippet metadata',
+      description: 'List all category/tag names and languages used across the user\'s snippets, plus a total count. Useful for building filters.',
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        const metadata = await snippetService.getMetadata(userId);
+        return ok(metadata);
+      } catch (error) {
+        Logger.error('MCP list_metadata failed:', error);
+        return fail('Failed to list metadata');
+      }
+    }
+  );
+
+  return server;
+}

--- a/server/src/middleware/mcpAuth.js
+++ b/server/src/middleware/mcpAuth.js
@@ -1,0 +1,88 @@
+import Logger from '../logger.js';
+import { validateApiKey } from '../repositories/apiKeyRepository.js';
+import { DISABLE_ACCOUNTS, getOrCreateAnonymousUser } from './auth.js';
+
+/*
+ * Authentication for the MCP endpoint.
+ *
+ * MCP is consumed by external AI clients (Claude desktop/web, OpenAI, Perplexity),
+ * which authenticate to remote servers with a bearer token. To "use the same token
+ * as the API" we accept a ByteStash API key in either of two ways:
+ *
+ *   - Authorization: Bearer <api-key>   (the convention every remote MCP client supports)
+ *   - x-api-key: <api-key>              (the header the existing ByteStash REST API uses)
+ *
+ * The key is validated against the same store as the REST API (api_keys table), so a
+ * key minted in the ByteStash UI works for both the API and MCP without any extra config.
+ *
+ * When the instance runs with DISABLE_ACCOUNTS=true there are no real users or keys, so
+ * we fall back to the shared anonymous user, mirroring the behaviour of authenticateToken.
+ */
+function extractApiKey(req) {
+  const authHeader = req.headers['authorization'];
+  if (authHeader && authHeader.toLowerCase().startsWith('bearer ')) {
+    return authHeader.slice(7).trim();
+  }
+
+  const apiKeyHeader = req.headers['x-api-key'];
+  if (apiKeyHeader) {
+    return apiKeyHeader.trim();
+  }
+
+  return null;
+}
+
+function unauthorized(res, message) {
+  res
+    .status(401)
+    .set('WWW-Authenticate', 'Bearer realm="ByteStash MCP", error="invalid_token"')
+    .json({
+      jsonrpc: '2.0',
+      error: { code: -32001, message },
+      id: null,
+    });
+}
+
+export async function authenticateMcp(req, res, next) {
+  const apiKey = extractApiKey(req);
+
+  if (!apiKey) {
+    if (DISABLE_ACCOUNTS) {
+      try {
+        const anonymousUser = await getOrCreateAnonymousUser();
+        req.user = anonymousUser;
+        return next();
+      } catch (error) {
+        Logger.error('Error in anonymous MCP authentication:', error);
+        return res.status(500).json({
+          jsonrpc: '2.0',
+          error: { code: -32603, message: 'Internal server error' },
+          id: null,
+        });
+      }
+    }
+
+    return unauthorized(res, 'Missing API key. Provide it as "Authorization: Bearer <key>" or the "x-api-key" header.');
+  }
+
+  try {
+    const result = validateApiKey(apiKey);
+
+    if (result) {
+      req.user = { id: result.userId };
+      req.apiKey = { id: result.keyId };
+      Logger.debug(`MCP request authenticated via API key ${result.keyId}`);
+      return next();
+    }
+
+    Logger.info('Invalid API key provided to MCP endpoint');
+    return unauthorized(res, 'Invalid API key');
+  } catch (error) {
+    Logger.error('Error validating API key for MCP:', error);
+    return res.status(500).json({
+      jsonrpc: '2.0',
+      error: { code: -32603, message: 'Internal server error' },
+      id: null,
+    });
+  }
+}

--- a/server/src/routes/mcpRoutes.js
+++ b/server/src/routes/mcpRoutes.js
@@ -1,0 +1,58 @@
+import express from 'express';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { createMcpServer } from '../mcp/snippetMcpServer.js';
+import Logger from '../logger.js';
+
+const router = express.Router();
+
+/*
+ * Remote MCP endpoint using the Streamable HTTP transport in stateless mode.
+ *
+ * Stateless mode (no session id) creates a fresh server + transport per request and
+ * returns the JSON-RPC response directly (enableJsonResponse). This keeps the endpoint
+ * horizontally scalable and free of session bookkeeping, which is all these read/write
+ * snippet tools need. `authenticateMcp` (mounted before this router) has already put the
+ * authenticated user on req.user.
+ */
+router.post('/', async (req, res) => {
+  let transport;
+  let server;
+  try {
+    server = createMcpServer(req.user.id);
+    transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: true,
+    });
+
+    res.on('close', () => {
+      transport.close();
+      server.close();
+    });
+
+    await server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+  } catch (error) {
+    Logger.error('Error handling MCP request:', error);
+    if (!res.headersSent) {
+      res.status(500).json({
+        jsonrpc: '2.0',
+        error: { code: -32603, message: 'Internal server error' },
+        id: null,
+      });
+    }
+  }
+});
+
+// Stateless mode does not support server-initiated streams or session teardown.
+function methodNotAllowed(req, res) {
+  res.status(405).json({
+    jsonrpc: '2.0',
+    error: { code: -32000, message: 'Method not allowed. Use POST for MCP requests.' },
+    id: null,
+  });
+}
+
+router.get('/', methodNotAllowed);
+router.delete('/', methodNotAllowed);
+
+export default router;

--- a/server/src/routes/mcpRoutes.js
+++ b/server/src/routes/mcpRoutes.js
@@ -15,8 +15,26 @@ const router = express.Router();
  * authenticated user on req.user.
  */
 router.post('/', async (req, res) => {
-  let transport;
-  let server;
+  let server = null;
+  let transport = null;
+
+  // Idempotent cleanup, shared by the normal-close listener and the error path,
+  // so resources are released exactly once whichever fires first (a throwing
+  // second close() in the 'close' listener would otherwise be uncaught).
+  let closed = false;
+  const cleanup = () => {
+    if (closed) return;
+    closed = true;
+    if (transport) {
+      try { transport.close(); } catch { /* ignore cleanup errors */ }
+    }
+    if (server) {
+      try { server.close(); } catch { /* ignore cleanup errors */ }
+    }
+  };
+
+  res.on('close', cleanup);
+
   try {
     server = createMcpServer(req.user.id);
     transport = new StreamableHTTPServerTransport({
@@ -24,15 +42,11 @@ router.post('/', async (req, res) => {
       enableJsonResponse: true,
     });
 
-    res.on('close', () => {
-      transport.close();
-      server.close();
-    });
-
     await server.connect(transport);
     await transport.handleRequest(req, res, req.body);
   } catch (error) {
     Logger.error('Error handling MCP request:', error);
+    cleanup();
     if (!res.headersSent) {
       res.status(500).json({
         jsonrpc: '2.0',


### PR DESCRIPTION
## Summary
Adds a remote [Model Context Protocol](https://modelcontextprotocol.io) endpoint so MCP-capable AI assistants (Claude desktop/web, OpenAI, Perplexity) can search and manage a user's snippets. It is served on the same host/port as the app and authenticated with the **existing ByteStash API key** — no new infrastructure, ports, or environment variables.

## What's added
- `POST ${BASE_PATH}/mcp` — MCP **Streamable HTTP** transport (stateless), via the official `@modelcontextprotocol/sdk`.
- **Auth** reuses the API-key store: `Authorization: Bearer <key>` or `x-api-key`. Falls back to the anonymous user when `DISABLE_ACCOUNTS=true`, mirroring the REST API. Tools are scoped to the key's owner — no broader access than the REST API grants.
- **Tools:** `list_snippets`, `get_snippet`, `create_snippet`, `update_snippet`, `delete_snippet`, `list_metadata`.

## Implementation
Additive only — no existing routes changed.

| File | Change |
|------|--------|
| `server/src/middleware/mcpAuth.js` | new — Bearer/`x-api-key` auth + anonymous fallback |
| `server/src/mcp/snippetMcpServer.js` | new — per-user MCP server with the snippet tools |
| `server/src/routes/mcpRoutes.js` | new — stateless Streamable HTTP route |
| `server/src/app.js` | mount `${basePath}/mcp` |
| `server/package.json` | added `@modelcontextprotocol/sdk` + `zod` |
| `server/scripts/mcp-smoke.mjs` | new — dependency-free end-to-end smoke test |
| `README.md`, `server/docs/swagger.yaml`, `docker-compose.yaml` | docs |

New deps `@modelcontextprotocol/sdk` and `zod` are picked up automatically by the existing Docker build (`npm install --omit=dev`).

## Testing
Verified end-to-end against a running server:
- JSON-RPC `initialize`, `tools/list` (all 6 tools), and a full `create → list → get → update → delete` round-trip.
- Both `Authorization: Bearer` and `x-api-key`; `401` for missing/invalid keys.
- Driven via curl, the included `server/scripts/mcp-smoke.mjs` (9/9 passing), and the official MCP Inspector.

```
BYTESTASH_API_KEY=<key> node server/scripts/mcp-smoke.mjs
```

## Client configuration
See the README "MCP (AI assistants)" section for Claude Desktop / Claude.ai / OpenAI Responses API / Perplexity snippets. Remote clients require HTTPS — terminate TLS at the reverse proxy/ingress as for the web UI.

## Scope notes
Bearer/API-key auth only (no OAuth). This works with Claude Desktop, OpenAI, Perplexity, and Claude.ai wherever a custom `Authorization` header can be set. Seamless Claude.ai-web connector support would need an OAuth 2.1 layer (cleanest path: proxy to the existing `OIDC_*` config) — intentionally left out of this PR to keep it small and focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
